### PR TITLE
Residualize stuck applications with `@lookup`s intact

### DIFF
--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.test.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.test.ts
@@ -1,5 +1,15 @@
 import either from '@matt.kantor/either'
+import option from '@matt.kantor/option'
 import assert from 'node:assert'
+import * as orderedRecord from '../../../../ordered-record.js'
+import {
+  compileWithoutSpans,
+  parseAndCompileAndRun,
+  testCases,
+  toSyntaxTree,
+} from '../../../../test-utilities.test.js'
+import type { Atom, Molecule } from '../../../parsing.js'
+import { parse } from '../../../parsing/parser.js'
 import { elaborationSuite, success } from '../test-utilities.test.js'
 
 elaborationSuite('@apply', [
@@ -371,3 +381,50 @@ elaborationSuite('@apply', [
     }),
   ],
 ])
+
+const stuckApplication =
+  '{ f: (n: :integer.type) => :n, x: @runtime { _context => 1 }, main: :f(:x) }'
+
+const valueAtKeyPath = (
+  value: Atom | Molecule,
+  keyPath: readonly string[],
+): Atom | Molecule | undefined =>
+  keyPath.reduce<Atom | Molecule | undefined>(
+    (valueSoFar, key) =>
+      valueSoFar === undefined || typeof valueSoFar === 'string' ?
+        undefined
+      : option.match(orderedRecord.get(valueSoFar, key), {
+          none: () => undefined,
+          some: propertyValue => propertyValue,
+        }),
+    value,
+  )
+
+testCases(
+  (input: string) => either.flatMap(parse(input), compileWithoutSpans),
+  input => `compiling \`${input}\``,
+)('residual form of stuck applications', [
+  [
+    stuckApplication,
+    output => {
+      assert(either.isRight(output))
+      assert.deepEqual(
+        valueAtKeyPath(output.value, ['main', '1', 'function', '0']),
+        '@lookup',
+      )
+    },
+  ],
+])
+
+testCases(parseAndCompileAndRun, input => `running \`${input}\``)(
+  'evaluation of stuck applications',
+  [
+    [
+      `${stuckApplication}.main`,
+      output => {
+        assert(either.isRight(output))
+        assert.deepEqual(output.value, toSyntaxTree('1'))
+      },
+    ],
+  ],
+)

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -10,7 +10,9 @@ import {
   getTypesForTypeParameters,
   inferType,
   isAssignable,
+  isExpression,
   isFunctionNode,
+  makeApplyExpression,
   readApplyExpression,
   rigidTypeParameterIdentities,
   stringifyTypeForEndUser,
@@ -190,15 +192,39 @@ export const applyKeywordHandler = (
       const functionToApply = applyExpression[1].function
       const argument = applyExpression[1].argument
 
+      // The residual form for stuck/deferred applications. Elaborated arguments
+      // are kept, but if the function was a `@lookup` in the source it stays
+      // that way when residualizing.
+      const residualFunction: SemanticGraph | undefined =
+        context.unelaboratedExpression === undefined ?
+          undefined
+        : either.match(readApplyExpression(context.unelaboratedExpression), {
+            right: unelaboratedApplyExpression => {
+              const unelaboratedFunctionToApply =
+                unelaboratedApplyExpression[1].function
+              return (
+                  isExpression(unelaboratedFunctionToApply) &&
+                    unelaboratedFunctionToApply['0'] === '@lookup'
+                ) ?
+                  unelaboratedFunctionToApply
+                : undefined
+            },
+            left: _ => undefined,
+          })
+      const residualApplyExpression =
+        residualFunction === undefined ? applyExpression : (
+          makeApplyExpression({ function: residualFunction, argument })
+        )
+
       if (containsAnyUnelaboratedNodes(argument)) {
         // The argument isn't ready, so keep the @apply unelaborated.
-        return either.makeRight(applyExpression)
+        return either.makeRight(residualApplyExpression)
       } else if (isFunctionNode(functionToApply)) {
         const result = functionToApply(argument, context)
         if (either.isLeft(result)) {
           if (result.value.kind === 'dependencyUnavailable') {
             // Keep the @apply unelaborated.
-            return either.makeRight(applyExpression)
+            return either.makeRight(residualApplyExpression)
           } else {
             return either.makeLeft(result.value)
           }
@@ -207,7 +233,7 @@ export const applyKeywordHandler = (
         }
       } else if (containsAnyUnelaboratedNodes(functionToApply)) {
         // The function isn't ready, so keep the @apply unelaborated.
-        return either.makeRight(applyExpression)
+        return either.makeRight(residualApplyExpression)
       } else {
         return either.makeLeft({
           kind: 'invalidExpression',

--- a/src/language/semantics/expression-elaboration.ts
+++ b/src/language/semantics/expression-elaboration.ts
@@ -100,8 +100,10 @@ export type ExpressionContext = {
    * aborting.
    */
   readonly panicsAreDeferred?: true | undefined
-  // The remaining properties are dynamic evaluation state (see
-  // `withDynamicEvaluationState`).
+
+  // The remaining properties are dynamic evaluation state (they describe the
+  // evaluation in progress rather than the program being elaborated).
+
   /**
    * Set while elaborating the body of a not-yet-applied `@function`. Function
    * applications occurring in such positions are speculative: their results
@@ -114,6 +116,10 @@ export type ExpressionContext = {
    * budget (see `configuration.ts`).
    */
   readonly applicationChain: readonly ApplicationChainEntry[]
+  /**
+   * The keyword expression currently being handled in its unelaborated form.
+   */
+  readonly unelaboratedExpression?: SemanticGraph | undefined
 }
 
 export type ApplicationChainEntry = {
@@ -126,11 +132,9 @@ export type ApplicationChainEntry = {
 }
 
 /**
- * Carry over what a from-scratch base context cannot know: `source`'s
- * configuration and its dynamic evaluation state (the state describing the
- * in-progress evaluation rather than the program being elaborated). The result
- * is otherwise `base`. Use this whenever an application's static context comes
- * from somewhere other than its call site.
+ * Copy configuration and application state to a new `ExpressionContext`. Use
+ * this whenever an application site's context comes from somewhere other than
+ * its call site (e.g. applications occurring within the standard library).
  */
 export const withDynamicEvaluationState = (
   base: ExpressionContext,
@@ -286,10 +290,10 @@ const elaborateWithinMolecule = (
   ) {
     // Keyword handlers are passed the raw expression; each handler explicitly
     // elaborates its own operands (typically via `elaborateOperands`).
-    return handleObjectNodeWhichMayBeAExpression(
-      moleculeAsSemanticGraph,
-      context,
-    )
+    return handleObjectNodeWhichMayBeAExpression(moleculeAsSemanticGraph, {
+      ...context,
+      unelaboratedExpression: moleculeAsSemanticGraph,
+    })
   } else {
     const propertiesResult = elaborateProperties(
       isSemanticGraph(molecule) ?
@@ -390,6 +394,7 @@ const elaborateWithinMolecule = (
                 ...context,
                 program: updatedProgram,
                 location: context.location,
+                unelaboratedExpression: moleculeAsSemanticGraph,
               },
             ),
         })


### PR DESCRIPTION
A stuck or deferred `@apply` of a looked-up function now residualizes with the `@lookup` intact, e.g. `:f(:g)` will keep `:f` unelaborated.

This is primarily to make re-entrancy guarding more robust. Previously the function would become an inline copy of its definition, which was not recognizable as the same function, which meant recursive calls could keep speculatively expanding instead of deferring at depth one.

See #250 for context.