### PR TITLE
Improve precedence/associativity of `~` and `|` operators

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -864,6 +864,32 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     }),
   ],
   [
+    // `(1 + 1) ~ 2`
+    '1 + 1 ~ 2',
+    success('2'),
+  ],
+  [
+    // `(1 + 1) | 3`
+    '1 + 1 | 3',
+    success({ '0': '@union', '1': { '0': '2', '1': '3' } }),
+  ],
+  [
+    // `false | ((1 + 1) ~ 2) | true`
+    'false | 1 + 1 ~ 2 | true',
+    success({ '0': '@union', '1': { '0': 'false', '1': '2', '2': 'true' } }),
+  ],
+  [
+    // `(a: :atom.type) => ((:a ~ :atom.type) ~ :atom.type)`
+    '(a: :atom.type) => :a ~ :atom.type ~ :atom.type',
+    assertSuccess,
+  ],
+  [
+    // `(stuff: {}) => ((:stuff object.lookup a) ~ :option.type(:something.type))`
+    '(stuff: {}) => :stuff object.lookup a ~ :option.type(:something.type)',
+    assertSuccess,
+  ],
+  [`(stuff: {}) => :stuff object.lookup a ~ :integer.type`, typeMismatch],
+  [
     `{
       |>: (f: ?a ~> ?b) => (a: :a) => :f(:a)
       ab: a |> :atom.append(b)

--- a/src/language/compiling/error-spans.test.ts
+++ b/src/language/compiling/error-spans.test.ts
@@ -59,6 +59,18 @@ suite('compile attaches source spans to elaboration errors', () => {
     assert.equal(source.slice(14, 22), ':missing')
   })
 
+  test('a check on an infix expression blames the whole expression', () => {
+    const source = '1 + 1 ~ :object.type'
+    assert.deepEqual(compileErrorSpan(source), [0, 5])
+    assert.equal(source.slice(0, 5), '1 + 1')
+  })
+
+  test('a check trailing a function body blames the body', () => {
+    const source = '(stuff: {}) => :stuff object.lookup a ~ :integer.type'
+    assert.deepEqual(compileErrorSpan(source), [15, 37])
+    assert.equal(source.slice(15, 37), ':stuff object.lookup a')
+  })
+
   test('an invalid parameter annotation blames the annotation', () => {
     const source = '(a: { [:something.type]: a }) => :a object.lookup a'
     assert.deepEqual(compileErrorSpan(source), [4, 28])

--- a/src/language/parsing/expression.ts
+++ b/src/language/parsing/expression.ts
@@ -39,6 +39,7 @@ import {
 } from './parentheses.js'
 import {
   recordSpan,
+  recordSpanExtending,
   spannedAtom,
   syntheticAtom,
   syntheticMolecule,
@@ -537,10 +538,9 @@ const trailingUnionTokens = map(
           flatMap(
             lazy(() => expressionWhichMayHaveTrailingExpressions),
             initialExpression =>
-              oneOf([
-                ...trailingExpressionsExceptUnion(initialExpression),
-                map(nothing, _ => initialExpression),
-              ]),
+              withTrailingExpressions({ unionsMayFollow: false })(
+                initialExpression,
+              ),
           ),
           trivia,
           unionBar,
@@ -857,19 +857,38 @@ const trailingUnionExpression = (initialExpression: SpannedTree) =>
     unionTokensToExpression([initialExpression, ...trailingUnionTokens]),
   )
 
-const trailingExpressionsExceptUnion = (initialExpression: SpannedTree) =>
-  [
-    trailingInfixExpression(initialExpression),
-    trailingSignatureExpression(initialExpression),
-    trailingCheckExpression(initialExpression),
-  ] as const
+/**
+ * Parse a chain of trailing expressions, each taking the previous parse result
+ * as its left-hand side. This lets `1 + 1 ~ 2` parse as `(1 + 1) ~ 2` rather
+ * than `1 + (1 ~ 2)`.
+ *
+ * Union members set `unionsMayFollow` to `false`, keeping `a | b | c` a single
+ * flat union (see `trailingUnionTokens`).
+ */
+const withTrailingExpressions =
+  (options: { readonly unionsMayFollow: boolean }) =>
+  (initialExpression: SpannedTree): Parser<SpannedTree> => {
+    const chainedAfter = (trailingExpression: Parser<SpannedTree>) =>
+      flatMap(
+        recordSpanExtending(initialExpression)(trailingExpression),
+        withTrailingExpressions(options),
+      )
+    return oneOf([
+      chainedAfter(trailingInfixExpression(initialExpression)),
+      // `@signature`s must be attempted before `@check`s: `>` is a valid atom,
+      // so `a ~>` would otherwise be parsed as `a ~ >`.
+      chainedAfter(trailingSignatureExpression(initialExpression)),
+      chainedAfter(trailingCheckExpression(initialExpression)),
+      ...(options.unionsMayFollow ?
+        [chainedAfter(trailingUnionExpression(initialExpression))]
+      : []),
+      map(nothing, _ => initialExpression),
+    ])
+  }
 
 export const expression: Parser<SpannedTree> = recordSpan(
-  flatMap(expressionWhichMayHaveTrailingExpressions, initialExpression =>
-    oneOf([
-      ...trailingExpressionsExceptUnion(initialExpression),
-      trailingUnionExpression(initialExpression),
-      map(nothing, _ => initialExpression),
-    ]),
+  flatMap(
+    expressionWhichMayHaveTrailingExpressions,
+    withTrailingExpressions({ unionsMayFollow: true }),
   ),
 )

--- a/src/language/parsing/spans.ts
+++ b/src/language/parsing/spans.ts
@@ -65,6 +65,26 @@ export const recordSpan =
     }))
 
 /**
+ * Like `recordSpan`, but for a node built around one which was already parsed
+ * (e.g. the `@check` which `a ~ b` builds around `a`). The produced node spans
+ * from where `initialNode` began through the end of what `parser` consumed.
+ */
+export const recordSpanExtending =
+  (initialNode: SpannedTree) =>
+  (parser: Parser<SpannedTree>): Parser<SpannedTree> =>
+  (input, offset = 0n) =>
+    either.map(parser(input, offset), success => ({
+      offset: success.offset,
+      output:
+        initialNode.span === undefined ?
+          success.output
+        : {
+            ...success.output,
+            span: spanEndingAt(initialNode.span, success.offset),
+          },
+    }))
+
+/**
  * Build a synthetic atom node (no source span of its own).
  */
 export const syntheticAtom = (value: Atom): SpannedAtom => ({
@@ -95,6 +115,8 @@ const spanFromOffsets = (start: bigint, end: bigint): Span => [
   Number(start),
   Number(end),
 ]
+
+const spanEndingAt = (span: Span, end: bigint): Span => [span[0], Number(end)]
 
 // Recursively find all spans within the given `node`.
 const spanEntries = (


### PR DESCRIPTION
For example: previously `(a: :integer.type) => :a + 1 ~ :integer.type` parsed as `((a: :integer.type) => :a + 1) ~ :integer.type` (which threw a type error because functions are not integers), now it parses as `(a: :integer.type) => ((:a + 1) ~ :integer.type)`.