### PR TITLE
Improve type signatures of some `object.*` standard library functions

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -890,6 +890,26 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [`(stuff: {}) => :stuff object.lookup a ~ :integer.type`, typeMismatch],
   [
+    `(stuff: { [:atom.type]: :integer.type }) => :stuff object.lookup a ~ :option.type(:integer.type)`,
+    assertSuccess,
+  ],
+  [
+    `(stuff: { [:atom.type]: :integer.type }) => :stuff object.lookup a ~ :option.type(:boolean.type)`,
+    typeMismatch,
+  ],
+  [
+    `(stuff: { [a | b]: :integer.type }) => :stuff object.lookup a ~ :option.type(:integer.type)`,
+    assertSuccess,
+  ],
+  [
+    `(stuff: { [a | b]: :integer.type }) => :stuff object.lookup c ~ :option.type(:integer.type)`,
+    typeMismatch,
+  ],
+  [
+    `((x: { [:atom.type]: :integer.type }) => :x)({ a: 42 }) ~ { a: 42 }`,
+    success({ a: '42' }),
+  ],
+  [
     `{
       |>: (f: ?a ~> ?b) => (a: :a) => :f(:a)
       ab: a |> :atom.append(b)

--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -1150,4 +1150,62 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   // Excess clause key types much be a subtype of `atom`.
   [`(a: { [:something.type]: a }) => _`, typeMismatch],
   [`(a: { [{}]: b }) => _`, typeMismatch],
+  [
+    `{
+      sum: (start_key: :natural_number.type) =>
+        (sequence: { [:natural_number.type]: :integer.type }) =>
+          :sequence object.lookup :start_key option.map (
+            (value1: :integer.type) =>
+              :sequence sum (:start_key + 1) match {
+                some: (value2: :integer.type) => :value1 + :value2
+                none: _ => :value1
+              }
+          )
+      results: {
+        from_start: :sum(0)({ 10, 20, 30 })
+        from_middle: :sum(1)({ 10, 20, 30 })
+        past_end: :sum(3)({ 10, 20, 30 })
+        empty: :sum(0)({})
+      }
+    }.results`,
+    success({
+      from_start: { tag: 'some', value: '60' },
+      from_middle: { tag: 'some', value: '50' },
+      past_end: { tag: 'none', value: {} },
+      empty: { tag: 'none', value: {} },
+    }),
+  ],
+  [
+    `{
+      sum: (start_key: :natural_number.type) =>
+        (sequence: { [:natural_number.type]: :integer.type }) =>
+          :sequence object.lookup :start_key option.map (
+            (value1: :integer.type) =>
+              :sequence sum (:start_key + 1) match {
+                some: (value2: :integer.type) => :value1 + :value2
+                none: _ => :value1
+              }
+          )
+      numbers: @runtime { _context => { 10, 20, 30 } }
+      start: @runtime { _context => 0 }
+      output: :numbers sum :start
+    }.output`,
+    success({ tag: 'some', value: '60' }),
+  ],
+  [
+    `{
+      even: (n: :integer.type) => @if { :n < 1, true, else: :odd(:n - 1) }
+      odd: (n: :integer.type) => @if { :n < 1, false, else: :even(:n - 1) }
+      results: {
+        six: :even(6)
+        seven: :even(7)
+        mapped: :option.make_some(6) option.map :even
+      }
+    }.results`,
+    success({
+      six: 'true',
+      seven: 'false',
+      mapped: { tag: 'some', value: 'true' },
+    }),
+  ],
 ])

--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -933,6 +933,36 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     success({ a: '42' }),
   ],
   [
+    `(key: :natural_number.type) =>
+      (stuff: { [:natural_number.type]: :integer.type }) =>
+        :stuff object.lookup :key ~ :option.type(:integer.type)`,
+    assertSuccess,
+  ],
+  [
+    `(key: :natural_number.type) =>
+      (stuff: { [:natural_number.type]: :integer.type }) =>
+        :stuff object.lookup :key ~ :option.type(:boolean.type)`,
+    typeMismatch,
+  ],
+  [
+    `(key: :atom.type) =>
+      (stuff: { [:natural_number.type]: :integer.type }) =>
+        :stuff object.lookup :key ~ :option.type(:integer.type)`,
+    typeMismatch,
+  ],
+  [
+    `(key: :natural_number.type) =>
+      (stuff: { [:atom.type]: :boolean.type, [:natural_number.type]: :integer.type }) =>
+        :stuff object.lookup :key ~ :option.type(:integer.type)`,
+    assertSuccess,
+  ],
+  [
+    `(key: :natural_number.type) =>
+      (stuff: { foo: true, [:natural_number.type]: :integer.type }) =>
+        :stuff object.lookup :key ~ :option.type(:integer.type)`,
+    assertSuccess,
+  ],
+  [
     `{
       |>: (f: ?a ~> ?b) => (a: :a) => :f(:a)
       ab: a |> :atom.append(b)

--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -906,6 +906,29 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     typeMismatch,
   ],
   [
+    `(stuff: { a: :integer.type } | { a: :boolean.type }) => :stuff object.lookup a ~ :option.type(:integer.type | :boolean.type)`,
+    assertSuccess,
+  ],
+  [
+    `(stuff: { a: :integer.type } | { a: :boolean.type }) => :stuff object.lookup a ~ :option.type(:integer.type)`,
+    typeMismatch,
+  ],
+  [
+    `(stuff: {
+      a: :integer.type
+      [:atom.type]: :nothing.type
+    } | {
+      b: :boolean.type
+      [:atom.type]: :nothing.type
+    }) => :stuff object.lookup a ~ :option.type(:integer.type)`,
+    assertSuccess,
+  ],
+  [
+    `(stuff: { a: :integer.type } | { b: :boolean.type }) =>
+      :stuff object.lookup a ~ :option.type(:integer.type)`,
+    typeMismatch,
+  ],
+  [
     `((x: { [:atom.type]: :integer.type }) => :x)({ a: 42 }) ~ { a: 42 }`,
     success({ a: '42' }),
   ],

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -2441,4 +2441,34 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `{
+      f: (stuff: { inner: { [:atom.type]: :integer.type } }) =>
+        :stuff.inner object.lookup a ~ :option.type(:integer.type)
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      f: (g: :atom.type ~> { [:atom.type]: :integer.type }) => (key: :atom.type) =>
+        :g(:key) object.lookup a ~ :option.type(:integer.type)
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      f: (key: @union { a, b }) =>
+        :object.from_property(:key)(1) ~ @union { { a: 1 }, { b: 1 } }
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -2471,4 +2471,28 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `(key: :natural_number.type) =>
+      (stuff: {
+        [:natural_number.type]: :integer.type
+      } | {
+        [:natural_number.type]: :boolean.type
+      }) =>
+        :stuff object.lookup :key ~ :option.type(:integer.type | :boolean.type)
+    `,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `(key: :integer.type) =>
+      (stuff: { [:integer.type]: :integer.type }) =>
+        :stuff object.lookup :key ~ :option.type(:integer.type)
+    `,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/semantics/stdlib/object.ts
+++ b/src/language/semantics/stdlib/object.ts
@@ -12,12 +12,15 @@ import {
   makeUnionType,
   types,
   unionOfTypes,
+  type ObjectType,
   type Type,
+  type UnionType,
 } from '../type-system.js'
 import {
   asUnionWithLiteralAtomMembers,
   effectiveExcessClauses,
   excessBoundForKey,
+  simplifyUnionType,
 } from '../type-system/subtyping.js'
 import { concreteUpperBound } from '../type-system/type-substitution.js'
 import { anyValue, atomParameter, objectParameter } from './parameters.js'
@@ -115,7 +118,7 @@ const computeOverlayReturnType = (parameterTypes: readonly Type[]): Type => {
  * possibly select. The `some` member is omitted when no value is selectable,
  * and the `none` member is omitted when the key definitely selects a value.
  */
-const lookupReturnType = ({
+const optionType = ({
   possibleValueTypes,
   mayBeNone,
 }: {
@@ -159,6 +162,78 @@ const literalKeyCandidates = (keyType: Type): Option<ReadonlySet<Atom>> => {
     : option.none
 }
 
+/**
+ * Every member of a union as an object type, or `none` when one or more members
+ * aren't object types.
+ */
+const memberObjectTypes = (
+  unionType: UnionType,
+): Option<readonly ObjectType[]> =>
+  option.sequence(
+    [...unionType.members].map(member => {
+      if (typeof member === 'string') {
+        return option.none
+      } else {
+        const memberBound = concreteUpperBound(member)
+        return memberBound.kind === 'object' ?
+            option.makeSome(memberBound)
+          : option.none
+      }
+    }),
+  )
+
+const lookupReturnTypeForObjectType = (
+  possibleKeys: Option<ReadonlySet<Atom>>,
+  objectType: ObjectType,
+): Type =>
+  option.match(possibleKeys, {
+    some: keys => {
+      const presentValueTypes = [...keys].flatMap(key => {
+        const valueType = objectType.children[key]
+        return valueType === undefined ? [] : [valueType]
+      })
+      const someKeyMayBeAbsent = presentValueTypes.length !== keys.size
+      const absentKeyBounds = [...keys]
+        .filter(key => objectType.children[key] === undefined)
+        .map(key => excessBoundForKey(key, objectType.excess))
+      return (
+        !someKeyMayBeAbsent ?
+          optionType({
+            possibleValueTypes: presentValueTypes,
+            mayBeNone: false,
+          })
+          // A key not among the children may exist as an unlisted property,
+          // whose value is bounded by the last clause matching the key.
+        : absentKeyBounds.some(bound => bound === types.something) ?
+          types.option(types.something)
+        : optionType({
+            possibleValueTypes: [
+              ...presentValueTypes,
+              ...absentKeyBounds.filter(bound => !isBottomType(bound)),
+            ],
+            mayBeNone: true,
+          })
+      )
+    },
+    none: _ => {
+      // Whatever the key turns out to be, it can only select one of the
+      // object's own property values, an unlisted property's value (bounded
+      // by the object's excess clauses), or nothing.
+      const objectExcess = effectiveExcessClauses(objectType.excess)
+      return objectExcess.some(clause => clause.values === types.something) ?
+          types.option(types.something)
+        : optionType({
+            possibleValueTypes: [
+              ...Object.values(objectType.children),
+              ...objectExcess
+                .map(clause => clause.values)
+                .filter(clauseValues => !isBottomType(clauseValues)),
+            ],
+            mayBeNone: true,
+          })
+    },
+  })
+
 // `lookup(key)(object)` returns `some(object[key])` when the key is definitely
 // present, `none` when definitely absent (e.g. a closed object lacking it),
 // otherwise a union covering all possible outcomes.
@@ -172,60 +247,31 @@ const computeLookupReturnType = (parameterTypes: readonly Type[]): Type => {
     throw new Error(
       '`lookup` function did not receive two arguments. This is a bug!',
     )
-  } else if (objectType.kind !== 'object') {
-    // TODO: Consider distributing over union members, so that looking a key up
-    // in `{ a: :integer.type } | { a: :boolean.type }` yields
-    // `:option.type(:integer.type | :boolean.type)`.
-    return types.option(types.something)
   } else {
-    return option.match(literalKeyCandidates(keyType), {
-      some: possibleKeys => {
-        const presentValueTypes = [...possibleKeys].flatMap(key => {
-          const valueType = objectType.children[key]
-          return valueType === undefined ? [] : [valueType]
+    const possibleKeys = literalKeyCandidates(keyType)
+    return (
+      objectType.kind === 'object' ?
+        lookupReturnTypeForObjectType(possibleKeys, objectType)
+      : objectType.kind === 'union' ?
+        // For each object-typed member, look up the property, then union the
+        // results. `{ a: 1 } | { a: 2 }` with key `a` emits `option(1 | 2)`.
+        option.match(memberObjectTypes(objectType), {
+          none: _ =>
+            // TODO: When one or more members are non-object types, could they
+            // be filtered out instead of giving up? A lookup on `a | { z: 1 }`
+            // can only ever return `option(1)`, after all.
+            types.option(types.something),
+          some: members =>
+            simplifyIfUnion(
+              unionOfTypes(
+                members.map(member =>
+                  lookupReturnTypeForObjectType(possibleKeys, member),
+                ),
+              ),
+            ),
         })
-        const someKeyMayBeAbsent =
-          presentValueTypes.length !== possibleKeys.size
-        const absentKeyBounds = [...possibleKeys]
-          .filter(key => objectType.children[key] === undefined)
-          .map(key => excessBoundForKey(key, objectType.excess))
-        return (
-          !someKeyMayBeAbsent ?
-            lookupReturnType({
-              possibleValueTypes: presentValueTypes,
-              mayBeNone: false,
-            })
-            // A key not among the children may exist as an unlisted property,
-            // whose value is bounded by the last clause matching the key.
-          : absentKeyBounds.some(bound => bound === types.something) ?
-            types.option(types.something)
-          : lookupReturnType({
-              possibleValueTypes: [
-                ...presentValueTypes,
-                ...absentKeyBounds.filter(bound => !isBottomType(bound)),
-              ],
-              mayBeNone: true,
-            })
-        )
-      },
-      none: _ => {
-        // Whatever the key turns out to be, it can only select one of the
-        // object's own property values, an unlisted property's value (bounded
-        // by the object's excess clauses), or nothing.
-        const objectExcess = effectiveExcessClauses(objectType.excess)
-        return objectExcess.some(clause => clause.values === types.something) ?
-            types.option(types.something)
-          : lookupReturnType({
-              possibleValueTypes: [
-                ...Object.values(objectType.children),
-                ...objectExcess
-                  .map(clause => clause.values)
-                  .filter(clauseValues => !isBottomType(clauseValues)),
-              ],
-              mayBeNone: true,
-            })
-      },
-    })
+      : types.option(types.something)
+    )
   }
 }
 
@@ -307,3 +353,6 @@ export const object = {
     computeOverlayReturnType,
   ),
 } as const
+
+const simplifyIfUnion = (type: Type): Type =>
+  type.kind === 'union' ? simplifyUnionType(type) : type

--- a/src/language/semantics/stdlib/object.ts
+++ b/src/language/semantics/stdlib/object.ts
@@ -19,7 +19,7 @@ import {
   effectiveExcessClauses,
   excessBoundForKey,
 } from '../type-system/subtyping.js'
-import { replaceAllTypeParametersWithTheirConstraints } from '../type-system/type-substitution.js'
+import { concreteUpperBound } from '../type-system/type-substitution.js'
 import { anyValue, atomParameter, objectParameter } from './parameters.js'
 import { computeFromReturnType } from './return-type-refiners.js'
 import { preludeFunction } from './stdlib-utilities.js'
@@ -33,29 +33,21 @@ const computeFromPropertyReturnType = (
       '`from_property` function did not receive two arguments. This is a bug!',
     )
   } else {
-    return option.match(
-      // TODO: Consider also supporting type parameters/stuck types via their
-      // upper bounds.
-      keyType.kind === 'union' ?
-        asUnionWithLiteralAtomMembers(keyType)
-      : option.none,
-      {
-        // The key isn't statically known, but every property value is the
-        // supplied one.
-        none: _ =>
-          makeObjectType({}, [{ keys: types.atom, values: valueType }]),
-        some: keys =>
-          unionOfTypes([
-            ...keys.members
-              .values()
-              .map(key =>
-                makeObjectType({ [key]: valueType }, [
-                  { keys: types.atom, values: types.nothing },
-                ]),
-              ),
-          ]),
-      },
-    )
+    return option.match(literalKeyCandidates(keyType), {
+      // The key isn't statically known, but every property value is the
+      // supplied one.
+      none: _ => makeObjectType({}, [{ keys: types.atom, values: valueType }]),
+      some: keys =>
+        unionOfTypes([
+          ...keys
+            .values()
+            .map(key =>
+              makeObjectType({ [key]: valueType }, [
+                { keys: types.atom, values: types.nothing },
+              ]),
+            ),
+        ]),
+    })
   }
 }
 
@@ -63,11 +55,11 @@ const computeOverlayReturnType = (parameterTypes: readonly Type[]): Type => {
   const [rawObject2Type, rawObject1Type] = parameterTypes
   const object2Type =
     rawObject2Type === undefined ? rawObject2Type : (
-      replaceAllTypeParametersWithTheirConstraints(rawObject2Type)
+      concreteUpperBound(rawObject2Type)
     )
   const object1Type =
     rawObject1Type === undefined ? rawObject1Type : (
-      replaceAllTypeParametersWithTheirConstraints(rawObject1Type)
+      concreteUpperBound(rawObject1Type)
     )
   if (object2Type === undefined || object1Type === undefined) {
     throw new Error(
@@ -160,30 +152,33 @@ const lookupReturnType = ({
 /**
  * Literal atoms the key could be at runtime (when statically enumerable).
  */
-const literalLookupKeyCandidates = (
-  keyType: Type,
-): Option<ReadonlySet<Atom>> =>
-  keyType.kind === 'union' ?
-    option.map(asUnionWithLiteralAtomMembers(keyType), union => union.members)
-  : keyType.kind === 'parameter' ?
-    literalLookupKeyCandidates(keyType.constraint.assignableTo)
-  : option.none
+const literalKeyCandidates = (keyType: Type): Option<ReadonlySet<Atom>> => {
+  const bound = concreteUpperBound(keyType)
+  return bound.kind === 'union' ?
+      option.map(asUnionWithLiteralAtomMembers(bound), union => union.members)
+    : option.none
+}
 
 // `lookup(key)(object)` returns `some(object[key])` when the key is definitely
 // present, `none` when definitely absent (e.g. a closed object lacking it),
 // otherwise a union covering all possible outcomes.
 const computeLookupReturnType = (parameterTypes: readonly Type[]): Type => {
-  const [keyType, objectType] = parameterTypes
+  const [keyType, rawObjectType] = parameterTypes
+  const objectType =
+    rawObjectType === undefined ? rawObjectType : (
+      concreteUpperBound(rawObjectType)
+    )
   if (keyType === undefined || objectType === undefined) {
     throw new Error(
       '`lookup` function did not receive two arguments. This is a bug!',
     )
   } else if (objectType.kind !== 'object') {
-    // TODO: Consider also supporting stuck/type-parameter object types via
-    // their upper bounds.
+    // TODO: Consider distributing over union members, so that looking a key up
+    // in `{ a: :integer.type } | { a: :boolean.type }` yields
+    // `:option.type(:integer.type | :boolean.type)`.
     return types.option(types.something)
   } else {
-    return option.match(literalLookupKeyCandidates(keyType), {
+    return option.match(literalKeyCandidates(keyType), {
       some: possibleKeys => {
         const presentValueTypes = [...possibleKeys].flatMap(key => {
           const valueType = objectType.children[key]

--- a/src/language/semantics/stdlib/object.ts
+++ b/src/language/semantics/stdlib/object.ts
@@ -7,6 +7,7 @@ import {
   orderedEntriesOfObjectNode,
 } from '../object-node.js'
 import {
+  isAssignable,
   isBottomType,
   makeObjectType,
   makeUnionType,
@@ -182,11 +183,32 @@ const memberObjectTypes = (
     }),
   )
 
+const excessClausesReachableFromKey = (
+  keyBound: Type,
+  excess: ObjectType['excess'],
+): ObjectType['excess'] => {
+  const clausesMatchEveryPossibleKey = (
+    clauses: ObjectType['excess'],
+  ): boolean =>
+    isAssignable({
+      source: keyBound,
+      target: unionOfTypes(clauses.map(clause => clause.keys)),
+    })
+  const matchableClauses =
+    clausesMatchEveryPossibleKey(excess) ? excess : (
+      effectiveExcessClauses(excess)
+    )
+  return matchableClauses.filter(
+    (_clause, index) =>
+      !clausesMatchEveryPossibleKey(matchableClauses.slice(index + 1)),
+  )
+}
+
 const lookupReturnTypeForObjectType = (
-  possibleKeys: Option<ReadonlySet<Atom>>,
+  keyType: Type,
   objectType: ObjectType,
 ): Type =>
-  option.match(possibleKeys, {
+  option.match(literalKeyCandidates(keyType), {
     some: keys => {
       const presentValueTypes = [...keys].flatMap(key => {
         const valueType = objectType.children[key]
@@ -218,14 +240,26 @@ const lookupReturnTypeForObjectType = (
     none: _ => {
       // Whatever the key turns out to be, it can only select one of the
       // object's own property values, an unlisted property's value (bounded
-      // by the object's excess clauses), or nothing.
-      const objectExcess = effectiveExcessClauses(objectType.excess)
-      return objectExcess.some(clause => clause.values === types.something) ?
+      // by the object's excess clauses), or nothing. Properties whose key the
+      // key type rules out are unselectable, so they bound nothing here.
+      const keyBound = concreteUpperBound(keyType)
+      const reachableExcess = excessClausesReachableFromKey(
+        keyBound,
+        objectType.excess,
+      )
+      return reachableExcess.some(clause => clause.values === types.something) ?
           types.option(types.something)
         : optionType({
             possibleValueTypes: [
-              ...Object.values(objectType.children),
-              ...objectExcess
+              ...Object.entries(objectType.children)
+                .filter(([key]) =>
+                  isAssignable({
+                    source: makeUnionType([key]),
+                    target: keyBound,
+                  }),
+                )
+                .map(([_key, valueType]) => valueType),
+              ...reachableExcess
                 .map(clause => clause.values)
                 .filter(clauseValues => !isBottomType(clauseValues)),
             ],
@@ -248,10 +282,9 @@ const computeLookupReturnType = (parameterTypes: readonly Type[]): Type => {
       '`lookup` function did not receive two arguments. This is a bug!',
     )
   } else {
-    const possibleKeys = literalKeyCandidates(keyType)
     return (
       objectType.kind === 'object' ?
-        lookupReturnTypeForObjectType(possibleKeys, objectType)
+        lookupReturnTypeForObjectType(keyType, objectType)
       : objectType.kind === 'union' ?
         // For each object-typed member, look up the property, then union the
         // results. `{ a: 1 } | { a: 2 }` with key `a` emits `option(1 | 2)`.
@@ -265,7 +298,7 @@ const computeLookupReturnType = (parameterTypes: readonly Type[]): Type => {
             simplifyIfUnion(
               unionOfTypes(
                 members.map(member =>
-                  lookupReturnTypeForObjectType(possibleKeys, member),
+                  lookupReturnTypeForObjectType(keyType, member),
                 ),
               ),
             ),

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -219,6 +219,23 @@ export const replaceAllTypeParametersWithTheirConstraints = (
       )
 
 /**
+ * The most specific upper bound of a type which is neither a type parameter nor
+ * a stuck type, if one exists. Types which are already concrete are returned
+ * unchanged, as are stuck types whose bounds can't be resolved further.
+ */
+export const concreteUpperBound = (type: Type): Type =>
+  matchTypeFormat(type, {
+    application: upperBoundOfResolvableStuckType,
+    function: _ => type,
+    indexedAccess: upperBoundOfResolvableStuckType,
+    intrinsicApplication: upperBoundOfResolvableStuckType,
+    object: _ => type,
+    opaque: _ => type,
+    parameter: type => concreteUpperBound(type.constraint.assignableTo),
+    union: _ => type,
+  })
+
+/**
  * The most specific resolvable upper bound of a stuck type, or `none` when
  * nothing further can be resolved.
  */
@@ -254,6 +271,14 @@ export const upperBoundOfStuckType = (
     }
   }
 }
+
+const upperBoundOfResolvableStuckType = (
+  stuckType: ApplicationType | IndexedAccessType | IntrinsicApplicationType,
+): Type =>
+  option.match(upperBoundOfStuckType(stuckType), {
+    none: _ => stuckType,
+    some: concreteUpperBound,
+  })
 
 /**
  * Finds concrete types for the `TypeParameter`s in `parameter` by locating the


### PR DESCRIPTION
Other functions got attention too, but many of the changes were focused on `object.lookup` so I'll use it as an illustrative example.

It gained the ability to reason argument types that are stuck and/or non-enumerable, for example this now returns an `option(boolean)`:
```plz
(key: :integer.type) =>
  (object: { [:integer.type]: :boolean.type }) =>
    :object object.lookup :key
```

It gained the ability to distribute over unions, for example this now returns an `option(integer | boolean)`:
```plz
(object: { a: :integer.type } | { a: :boolean.type }) =>
  :object object.lookup a
```

---

This changeset was primarily driven by a desire to get programs like this to typecheck:

```plz
{
  sum_from: (index: :natural_number.type) =>
    (sequence: { [:natural_number.type]: :integer.type }) =>
      :sequence object.lookup :index option.map (
        (a: :integer.type) =>
          :sequence sum_from (:index + 1) match {
            some: (b: :integer.type) => :a + :b
            none: _ => :a
          }
      )
  sum: :sum_from(0)
}.sum({ 1, 2, 3, 4 }).value
```

That now outputs `10`.