### PR TITLE
Introduce `:PascalCase` type aliases, make them idiomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ annotated:
 
 ```plz
 {
-  increment: (a: :integer.type) => :a + 1
+  increment: (a: :Integer) => :a + 1
 }
 ```
 
@@ -277,7 +277,7 @@ The `~` operator (syntax sugar for the `@check` keyword) can be used to annotate
 the type of expressions:
 
 ```plz
-:a ~ :boolean.type
+:a ~ :Boolean
 ```
 
 An error will be raised at compile time if `:a` is not a boolean value.
@@ -310,8 +310,8 @@ example:
 
 ```plz
 {
-  integer_identity: (n: :integer.type) => :n
-  answer: :integer_identity(42) ~ 42 // return type is `42`, not `:integer.type`
+  integer_identity: (n: :Integer) => :n
+  answer: :integer_identity(42) ~ 42 // return type is `42`, not `:Integer`
 }
 ```
 
@@ -334,8 +334,8 @@ two functions mean the same thing:
 
 ```plz
 {
-  integer_identity_1: (n: (?n: :integer.type)) => :n
-  integer_identity_2: (n: :integer.type) => :n
+  integer_identity_1: (n: (?n: :Integer)) => :n
+  integer_identity_2: (n: :Integer) => :n
 }
 ```
 
@@ -347,13 +347,13 @@ are closed under addition, so the return value of the below function is
 statically known to be a natural number:
 
 ```plz
-(a: :natural_number.type) => (:a + 1) ~ :natural_number.type
+(a: :NaturalNumber) => (:a + 1) ~ :NaturalNumber
 ```
 
 Subtraction can underflow, so it _isn't_ closed over the natural numbers like
 addition. An analogous program using `:a - 1` is rejected at compile time
-because the inferred type is only `:integer.type` (`:a` could be `0`, then
-`:a - 1` would be `-1` which isn't a natural number).
+because the inferred type is only `:Integer` (`:a` could be `0`, then `:a - 1`
+would be `-1` which isn't a natural number).
 
 Please also understands that indexing an object will yield one of the values
 that specific key could select:
@@ -370,7 +370,7 @@ reason about the condition, Please knows which branch will be executed:
 
 ```plz
 {
-  classify: (a: :integer.type) =>
+  classify: (a: :Integer) =>
     @if {
       :a < 0
       then: negative

--- a/examples/.snapshot
+++ b/examples/.snapshot
@@ -54,7 +54,7 @@ exports[`examples > fibonacci.plz > --input=\"not a number\" > stdout 1`] = `
 
 exports[`examples > fibonacci.plz > roundtripped syntax tree 1`] = `
 {
-  fibonacci: (n: :integer.type) => @if {
+  fibonacci: (n: :Integer) => @if {
     (:n < 2)
     then: :n
     else: :fibonacci(:n - 1) + :fibonacci(:n - 2)
@@ -148,11 +148,11 @@ exports[`examples > fizzbuzz.plz > --input=\"not a number\" > stdout 1`] = `
 
 exports[`examples > fizzbuzz.plz > roundtripped syntax tree 1`] = `
 {
-  fizzbuzz: (limit: :natural_number.type) => {
+  fizzbuzz: (limit: :NaturalNumber) => {
     fizzbuzz_internal: (state: {
-      current: :natural_number.type
+      current: :NaturalNumber
       output: {
-        [:atom.type]: :natural_number.type | Fizz | Buzz | FizzBuzz
+        [:Atom]: :NaturalNumber | Fizz | Buzz | FizzBuzz
       }
     }) => @if {
       (:state.current > :limit)
@@ -264,7 +264,7 @@ exports[`examples > greatest-common-divisor.plz > --a=\"not a number\" --b=5 > s
 
 exports[`examples > greatest-common-divisor.plz > roundtripped syntax tree 1`] = `
 {
-  gcd: (a: :natural_number.type) => (b: :natural_number.type) => @if {
+  gcd: (a: :NaturalNumber) => (b: :NaturalNumber) => @if {
     (:b integer.equals 0)
     then: :a
     else: :a % :b gcd :b
@@ -277,9 +277,9 @@ exports[`examples > greatest-common-divisor.plz > roundtripped syntax tree 1`] =
   }
   output: :input.a match {
     none: _ => "missing or invalid --a argument (must be a natural number)"
-    some: (a: :natural_number.type) => :input.b match {
+    some: (a: :NaturalNumber) => :input.b match {
       none: _ => "missing or invalid --b argument (must be a natural number)"
-      some: (b: :natural_number.type) => :b gcd :a
+      some: (b: :NaturalNumber) => :b gcd :a
     }
   }
 }.output
@@ -355,8 +355,8 @@ exports[`examples > greet.plz > roundtripped syntax tree 1`] = `
     context => :context.arguments.lookup(name)
   } option.get_or_else user
   sentence: (parts: {
-    :atom.type
-    :atom.type
+    :Atom
+    :Atom
   }) => :parts.0 atom.append :name atom.append :parts.1
   greetings: {
     de: :sentence({
@@ -386,7 +386,7 @@ exports[`examples > greet.plz > roundtripped syntax tree 1`] = `
   }
   output: @runtime {
     context => :context.arguments.lookup(language)
-  } option.flat_map ((code: :atom.type) => :greetings object.lookup :code) option.get_or_else :greetings.en
+  } option.flat_map ((code: :Atom) => :greetings object.lookup :code) option.get_or_else :greetings.en
 }.output
 
 `;
@@ -465,7 +465,7 @@ exports[`examples > is-prime.plz > --input=\"not a number\" > stdout 1`] = `
 
 exports[`examples > is-prime.plz > roundtripped syntax tree 1`] = `
 {
-  try_divisor: (n: :natural_number.type) => (divisor: :natural_number.type) => @if {
+  try_divisor: (n: :NaturalNumber) => (divisor: :NaturalNumber) => @if {
     (:divisor * :divisor > :n)
     then: true
     else: @if {
@@ -474,7 +474,7 @@ exports[`examples > is-prime.plz > roundtripped syntax tree 1`] = `
       else: :divisor + 1 try_divisor :n
     }
   }
-  is_prime: (n: :natural_number.type) => @if {
+  is_prime: (n: :NaturalNumber) => @if {
     (:n < 2)
     then: false
     else: 2 try_divisor :n
@@ -509,7 +509,7 @@ exports[`examples > kitchen-sink.plz > roundtripped syntax tree 1`] = `
     green
     blue
   }
-  two: (1 + 1) ~ :integer.type
+  two: (1 + 1) ~ :Integer
   add_one: :integer.add(1)
   three: :add_one(:two)
   function: x => {

--- a/examples/fibonacci.plz
+++ b/examples/fibonacci.plz
@@ -4,7 +4,7 @@
  * Usage: cat ./examples/fibonacci.plz | ./please --input=7
  */
 {
-  fibonacci: (n: :integer.type) =>
+  fibonacci: (n: :Integer) =>
     @if {
       :n < 2
       then: :n

--- a/examples/fizzbuzz.plz
+++ b/examples/fizzbuzz.plz
@@ -4,10 +4,10 @@
  * Usage: cat ./examples/fizzbuzz.plz | ./please --input=15
  */
 {
-  fizzbuzz: (limit: :natural_number.type) => {
+  fizzbuzz: (limit: :NaturalNumber) => {
     fizzbuzz_internal: (state: {
-      current: :natural_number.type
-      output: { [:atom.type]: :natural_number.type | Fizz | Buzz | FizzBuzz }
+      current: :NaturalNumber
+      output: { [:Atom]: :NaturalNumber | Fizz | Buzz | FizzBuzz }
     }) => @if {
       :state.current > :limit
       then: :state.output

--- a/examples/greatest-common-divisor.plz
+++ b/examples/greatest-common-divisor.plz
@@ -5,7 +5,7 @@
  * Usage: cat ./examples/greatest-common-divisor.plz | ./please --a=12 --b=18
  */
 {
-  gcd: (a: :natural_number.type) => (b: :natural_number.type) => @if {
+  gcd: (a: :NaturalNumber) => (b: :NaturalNumber) => @if {
     :b integer.equals 0
     then: :a
     else: :gcd(:b)(:a % :b)
@@ -18,9 +18,9 @@
 
   output: :input.a match {
     none: _ => "missing or invalid --a argument (must be a natural number)"
-    some: ((a: :natural_number.type) => :input.b match {
+    some: ((a: :NaturalNumber) => :input.b match {
       none: _ => "missing or invalid --b argument (must be a natural number)"
-      some: ((b: :natural_number.type) => :gcd(:a)(:b))
+      some: ((b: :NaturalNumber) => :gcd(:a)(:b))
     })
   }
 }.output

--- a/examples/greet.plz
+++ b/examples/greet.plz
@@ -10,7 +10,7 @@
   name: @runtime { context => :context.arguments.lookup(name) }
     option.get_or_else user
 
-  sentence: (parts: { :atom.type, :atom.type }) =>
+  sentence: (parts: { :Atom, :Atom }) =>
     :parts.0 atom.append :name atom.append :parts.1
 
   greetings: {
@@ -23,6 +23,6 @@
   }
 
   output: @runtime { context => :context.arguments.lookup(language) }
-    option.flat_map ((code: :atom.type) => :greetings object.lookup :code)
+    option.flat_map ((code: :Atom) => :greetings object.lookup :code)
     option.get_or_else :greetings.en
 }.output

--- a/examples/is-prime.plz
+++ b/examples/is-prime.plz
@@ -5,7 +5,7 @@
  * Usage: cat ./examples/is-prime.plz | ./please --input=17
  */
 {
-  try_divisor: (n: :natural_number.type) => (divisor: :natural_number.type) =>
+  try_divisor: (n: :NaturalNumber) => (divisor: :NaturalNumber) =>
     @if {
       :divisor * :divisor > :n
       then: true
@@ -16,7 +16,7 @@
       }
     }
 
-  is_prime: (n: :natural_number.type) => @if {
+  is_prime: (n: :NaturalNumber) => @if {
     :n < 2
     then: false
     else: :try_divisor(:n)(2)

--- a/examples/kitchen-sink.plz
+++ b/examples/kitchen-sink.plz
@@ -4,7 +4,7 @@
   bar: :foo
   sky_is_blue: :boolean.not(false)
   colors: { red, green, blue }
-  two: (1 + 1) ~ :integer.type
+  two: (1 + 1) ~ :Integer
   add_one: :integer.add(1)
   three: :add_one(:two)
   function: x => { value: :x }

--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -105,8 +105,8 @@ testCases(parseAndCompileAndRun, code => code)('runtime-derived values', [
     success('42'),
   ],
   [
-    `((a: :natural_number.type) => {
-      my_function: (b: :natural_number.type) => @if {
+    `((a: :NaturalNumber) => {
+      my_function: (b: :NaturalNumber) => @if {
         :b > :a
         then: @panic "should not go down this branch"
         else: 2 + @if {
@@ -121,8 +121,8 @@ testCases(parseAndCompileAndRun, code => code)('runtime-derived values', [
   ],
   [
     `{
-      count: (limit: :natural_number.type) => {
-        count_internal: (state: { current: :integer.type, output: :atom.type }) =>
+      count: (limit: :NaturalNumber) => {
+        count_internal: (state: { current: :Integer, output: :Atom }) =>
           @if {
             :state.current > :limit
             then: :state.output
@@ -474,7 +474,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     `{
-      fibonacci: (n: :integer.type) =>
+      fibonacci: (n: :Integer) =>
         @if {
           :integer.is_less_than(2)(:n)
           then: :n
@@ -486,7 +486,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     `{
-      +: (a: :integer.type) => (b: :integer.type) => :integer.add(:a)(:b)
+      +: (a: :Integer) => (b: :Integer) => :integer.add(:a)(:b)
       result: 1 + 1
      }.result`,
     success('2'),
@@ -501,7 +501,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   [`0 > 0`, success('false')],
   [`1 < 0`, success('false')],
   [`0 > 1`, success('false')],
-  [`((a: :integer.type) => (1 + :a))(1)`, success('2')],
+  [`((a: :Integer) => (1 + :a))(1)`, success('2')],
   [`2 |> (a => :a)`, success('2')],
   [`a atom.append b atom.append c`, success('abc')],
   [`b atom.append c atom.prepend a`, success('abc')],
@@ -636,7 +636,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   [':option.make_some(value) option.get_or_else fallback', success('value')],
   [':option.none |> :option.get_or_else(fallback)', success('fallback')],
   [
-    '((a: :atom.type) => (:option.make_some(:a) option.get_or_else other) ~ :atom.type)(hello)',
+    '((a: :Atom) => (:option.make_some(:a) option.get_or_else other) ~ :Atom)(hello)',
     success('hello'),
   ],
   [':option.is_some(:option.make_some(7))', success('true')],
@@ -644,17 +644,17 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   [':option.is_none(:option.none)', success('true')],
   [':option.is_none(:option.make_some(7))', success('false')],
   [
-    `:option.make_some(key) option.flat_map ((a: :atom.type) => { key: value } object.lookup :a)`,
+    `:option.make_some(key) option.flat_map ((a: :Atom) => { key: value } object.lookup :a)`,
     success({ tag: 'some', value: 'value' }),
   ],
   [
-    `((code: :atom.type) =>
-      ({ en: Hello, es: Hola } object.lookup :code option.get_or_else Hi) ~ :atom.type
+    `((code: :Atom) =>
+      ({ en: Hello, es: Hola } object.lookup :code option.get_or_else Hi) ~ :Atom
     )(es)`,
     success('Hola'),
   ],
-  [`((x: { a: :integer.type }) => :x.a)({ a: 42, b: extra })`, success('42')],
-  [`((x: :object.type) => :x)({ a: 1, b: {} })`, success({ a: '1', b: {} })],
+  [`((x: { a: :Integer }) => :x.a)({ a: 42, b: extra })`, success('42')],
+  [`((x: :Object) => :x)({ a: 1, b: {} })`, success({ a: '1', b: {} })],
   [
     // Lookups should never target keyword expression properties.
     `{
@@ -712,11 +712,11 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     `{
-      a: 42 assume :natural_number.type
-      b: true ~ :boolean.type
-      c: {} ~ :object.type
-      d: { z: -42 } assume { z: :integer.type }
-      e: "not a number" assume @union { :integer.type, "not a number" }
+      a: 42 assume :NaturalNumber
+      b: true ~ :Boolean
+      c: {} ~ :Object
+      d: { z: -42 } assume { z: :Integer }
+      e: "not a number" assume @union { :Integer, "not a number" }
     }`,
     success({
       a: '42',
@@ -726,7 +726,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       e: 'not a number',
     }),
   ],
-  [`"not a number" assume :integer.type`, typeMismatch],
+  [`"not a number" assume :Integer`, typeMismatch],
   [
     `@runtime { context =>
       :context.environment.lookup("not a legal environment variable name")
@@ -736,10 +736,10 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     }`,
     success('a'),
   ],
-  [`((a: :integer.type) => (b: :integer.type) => :a + :b)(1)(1)`, success('2')],
+  [`((a: :Integer) => (b: :Integer) => :a + :b)(1)(1)`, success('2')],
   [
     `{
-      f: (state: { current: :integer.type, limit: :integer.type }) => @if {
+      f: (state: { current: :Integer, limit: :Integer }) => @if {
         :state.current > :state.limit
         then: "it works"
         else: :f({
@@ -751,7 +751,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     success('it works'),
   ],
   [
-    `((inner: { a: :boolean.type }) => @if {
+    `((inner: { a: :Boolean }) => @if {
       :inner.a
       then: "it works"
       else: { @panic }
@@ -759,8 +759,8 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     success('it works'),
   ],
   [
-    `((outer: :boolean.type) =>
-      ((inner: { value: :boolean.type }) =>
+    `((outer: :Boolean) =>
+      ((inner: { value: :Boolean }) =>
         @if {
           condition: :boolean.or(:outer)(:inner.value)
           then: { @panic }
@@ -771,8 +771,8 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     success('true'),
   ],
   [
-    `((outer: :boolean.type) =>
-      ((inner: { value: :boolean.type }) =>
+    `((outer: :Boolean) =>
+      ((inner: { value: :Boolean }) =>
         @if {
           condition: :boolean.or(:outer)(:inner.value)
           then: "it works"
@@ -782,8 +782,8 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     )(true)`,
     success('it works'),
   ],
-  [`(:boolean.not ~ (:boolean.type ~> :boolean.type))(false)`, success('true')],
-  [`:boolean.not ~ (:boolean.type ~> :integer.type)`, typeMismatch],
+  [`(:boolean.not ~ (:Boolean ~> :Boolean))(false)`, success('true')],
+  [`:boolean.not ~ (:Boolean ~> :Integer)`, typeMismatch],
   [
     `{ 1 integer.equals 1, 1 integer.equals 2 }`,
     success({ 0: 'true', 1: 'false' }),
@@ -800,17 +800,17 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     ),
   ],
   [`:object.from_property(key)(value)`, success({ key: 'value' })],
-  [`(1 + 1) ~ :integer.type`, success('2')],
+  [`(1 + 1) ~ :Integer`, success('2')],
   [
     `{
-      1 ~ :something.type
-      blah ~ :something.type
-      {} ~ :something.type
-      (a => :a) ~ :something.type
+      1 ~ :Something
+      blah ~ :Something
+      {} ~ :Something
+      (a => :a) ~ :Something
     }`,
     assertSuccess,
   ],
-  [`"arbitrary value" ~ :nothing.type`, typeMismatch],
+  [`"arbitrary value" ~ :Nothing`, typeMismatch],
   [
     // `true | (false || true) | false`
     'true | false || true | false',
@@ -879,87 +879,87 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     success({ '0': '@union', '1': { '0': 'false', '1': '2', '2': 'true' } }),
   ],
   [
-    // `(a: :atom.type) => ((:a ~ :atom.type) ~ :atom.type)`
-    '(a: :atom.type) => :a ~ :atom.type ~ :atom.type',
+    // `(a: :Atom) => ((:a ~ :Atom) ~ :Atom)`
+    '(a: :Atom) => :a ~ :Atom ~ :Atom',
     assertSuccess,
   ],
   [
-    // `(stuff: {}) => ((:stuff object.lookup a) ~ :option.type(:something.type))`
-    '(stuff: {}) => :stuff object.lookup a ~ :option.type(:something.type)',
+    // `(stuff: {}) => ((:stuff object.lookup a) ~ :Option(:Something))`
+    '(stuff: {}) => :stuff object.lookup a ~ :Option(:Something)',
     assertSuccess,
   ],
-  [`(stuff: {}) => :stuff object.lookup a ~ :integer.type`, typeMismatch],
+  [`(stuff: {}) => :stuff object.lookup a ~ :Integer`, typeMismatch],
   [
-    `(stuff: { [:atom.type]: :integer.type }) => :stuff object.lookup a ~ :option.type(:integer.type)`,
+    `(stuff: { [:Atom]: :Integer }) => :stuff object.lookup a ~ :Option(:Integer)`,
     assertSuccess,
   ],
   [
-    `(stuff: { [:atom.type]: :integer.type }) => :stuff object.lookup a ~ :option.type(:boolean.type)`,
+    `(stuff: { [:Atom]: :Integer }) => :stuff object.lookup a ~ :Option(:Boolean)`,
     typeMismatch,
   ],
   [
-    `(stuff: { [a | b]: :integer.type }) => :stuff object.lookup a ~ :option.type(:integer.type)`,
+    `(stuff: { [a | b]: :Integer }) => :stuff object.lookup a ~ :Option(:Integer)`,
     assertSuccess,
   ],
   [
-    `(stuff: { [a | b]: :integer.type }) => :stuff object.lookup c ~ :option.type(:integer.type)`,
+    `(stuff: { [a | b]: :Integer }) => :stuff object.lookup c ~ :Option(:Integer)`,
     typeMismatch,
   ],
   [
-    `(stuff: { a: :integer.type } | { a: :boolean.type }) => :stuff object.lookup a ~ :option.type(:integer.type | :boolean.type)`,
+    `(stuff: { a: :Integer } | { a: :Boolean }) => :stuff object.lookup a ~ :Option(:Integer | :Boolean)`,
     assertSuccess,
   ],
   [
-    `(stuff: { a: :integer.type } | { a: :boolean.type }) => :stuff object.lookup a ~ :option.type(:integer.type)`,
+    `(stuff: { a: :Integer } | { a: :Boolean }) => :stuff object.lookup a ~ :Option(:Integer)`,
     typeMismatch,
   ],
   [
     `(stuff: {
-      a: :integer.type
-      [:atom.type]: :nothing.type
+      a: :Integer
+      [:Atom]: :Nothing
     } | {
-      b: :boolean.type
-      [:atom.type]: :nothing.type
-    }) => :stuff object.lookup a ~ :option.type(:integer.type)`,
+      b: :Boolean
+      [:Atom]: :Nothing
+    }) => :stuff object.lookup a ~ :Option(:Integer)`,
     assertSuccess,
   ],
   [
-    `(stuff: { a: :integer.type } | { b: :boolean.type }) =>
-      :stuff object.lookup a ~ :option.type(:integer.type)`,
+    `(stuff: { a: :Integer } | { b: :Boolean }) =>
+      :stuff object.lookup a ~ :Option(:Integer)`,
     typeMismatch,
   ],
   [
-    `((x: { [:atom.type]: :integer.type }) => :x)({ a: 42 }) ~ { a: 42 }`,
+    `((x: { [:Atom]: :Integer }) => :x)({ a: 42 }) ~ { a: 42 }`,
     success({ a: '42' }),
   ],
   [
-    `(key: :natural_number.type) =>
-      (stuff: { [:natural_number.type]: :integer.type }) =>
-        :stuff object.lookup :key ~ :option.type(:integer.type)`,
+    `(key: :NaturalNumber) =>
+      (stuff: { [:NaturalNumber]: :Integer }) =>
+        :stuff object.lookup :key ~ :Option(:Integer)`,
     assertSuccess,
   ],
   [
-    `(key: :natural_number.type) =>
-      (stuff: { [:natural_number.type]: :integer.type }) =>
-        :stuff object.lookup :key ~ :option.type(:boolean.type)`,
+    `(key: :NaturalNumber) =>
+      (stuff: { [:NaturalNumber]: :Integer }) =>
+        :stuff object.lookup :key ~ :Option(:Boolean)`,
     typeMismatch,
   ],
   [
-    `(key: :atom.type) =>
-      (stuff: { [:natural_number.type]: :integer.type }) =>
-        :stuff object.lookup :key ~ :option.type(:integer.type)`,
+    `(key: :Atom) =>
+      (stuff: { [:NaturalNumber]: :Integer }) =>
+        :stuff object.lookup :key ~ :Option(:Integer)`,
     typeMismatch,
   ],
   [
-    `(key: :natural_number.type) =>
-      (stuff: { [:atom.type]: :boolean.type, [:natural_number.type]: :integer.type }) =>
-        :stuff object.lookup :key ~ :option.type(:integer.type)`,
+    `(key: :NaturalNumber) =>
+      (stuff: { [:Atom]: :Boolean, [:NaturalNumber]: :Integer }) =>
+        :stuff object.lookup :key ~ :Option(:Integer)`,
     assertSuccess,
   ],
   [
-    `(key: :natural_number.type) =>
-      (stuff: { foo: true, [:natural_number.type]: :integer.type }) =>
-        :stuff object.lookup :key ~ :option.type(:integer.type)`,
+    `(key: :NaturalNumber) =>
+      (stuff: { foo: true, [:NaturalNumber]: :Integer }) =>
+        :stuff object.lookup :key ~ :Option(:Integer)`,
     assertSuccess,
   ],
   [
@@ -989,7 +989,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   [
     `{
       increment: @function {
-        parameter: { a: :integer.type }
+        parameter: { a: :Integer }
         body: :a + 1
       }
       two: :increment(1)
@@ -1013,14 +1013,14 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     `(x: @object {
       properties: {}
       excess: {
-        { :atom.type, :nothing.type }
-        { :natural_number.type, :atom.type }
+        { :Atom, :Nothing }
+        { :NaturalNumber, :Atom }
       }
     }) =>
       (:x ~ @object {
         properties: {}
         excess: {
-          { :atom.type, :atom.type }
+          { :Atom, :Atom }
         }
       })`,
     assertSuccess,
@@ -1029,31 +1029,31 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     `(x: @object {
       properties: {}
       excess: {
-        { :atom.type, :atom.type }
+        { :Atom, :Atom }
       }
     }) =>
       (:x ~ @object {
         properties: {}
         excess: {
-          { :atom.type, :atom.type }
-          { :natural_number.type, :integer.type }
+          { :Atom, :Atom }
+          { :NaturalNumber, :Integer }
         }
       })`,
     typeMismatch,
   ],
   [
     `(x: @object {
-      properties: { a: :integer.type }
+      properties: { a: :Integer }
       excess: {
-        { :atom.type, :atom.type }
-        { :natural_number.type, :integer.type }
+        { :Atom, :Atom }
+        { :NaturalNumber, :Integer }
       }
     }) =>
-      (:object.lookup(5)(:x) ~ :option.type(:integer.type))`,
+      (:object.lookup(5)(:x) ~ :Option(:Integer))`,
     assertSuccess,
   ],
   [
-    `(o: :object.type) => {
+    `(o: :Object) => {
       first: :o object.lookup 0
       return: :identity(:first.value)
     }.return`,
@@ -1067,97 +1067,91 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     success({ deferred: { value: '1' }, out: '1' }),
   ],
   [
-    `(o: :object.type) => {
+    `(o: :Object) => {
       first: :o object.lookup 0
       return: :first.value + 1
     }.return`,
     typeMismatch,
   ],
   [
-    `(o: :object.type) => {
+    `(o: :Object) => {
       first: :o object.lookup 0
       return: :first.value(1)
     }.return`,
     invalidExpression,
   ],
   [
-    `(x: { a: :atom.type }) => (y: { b: :atom.type }) =>
+    `(x: { a: :Atom }) => (y: { b: :Atom }) =>
       (:object.overlay(:x)(:y) ~ @object {
-        properties: { a: :atom.type, b: :something.type }
+        properties: { a: :Atom, b: :Something }
         excess: {
-          { :atom.type, :nothing.type }
+          { :Atom, :Nothing }
         }
       })`,
     typeMismatch,
   ],
   [
-    `:match({ a: (v: :integer.type) => :v })({ tag: a, value: hello })`,
+    `:match({ a: (v: :Integer) => :v })({ tag: a, value: hello })`,
     typeMismatch,
   ],
   [
-    `:match({ a: (v: :integer.type) => :v + 1 })({ tag: a, value: 41 })`,
+    `:match({ a: (v: :Integer) => :v + 1 })({ tag: a, value: 41 })`,
     success('42'),
   ],
   [
-    `((x: { [:atom.type]: :integer.type }) => :x)({ a: 1, b: 2 })`,
+    `((x: { [:Atom]: :Integer }) => :x)({ a: 1, b: 2 })`,
     success({ a: '1', b: '2' }),
   ],
-  [`((x: { [:atom.type]: :integer.type }) => :x)({ a: hello })`, typeMismatch],
+  [`((x: { [:Atom]: :Integer }) => :x)({ a: hello })`, typeMismatch],
   [
-    `((x: { [:atom.type]: :nothing.type, a: :integer.type }) => :x)({ a: 1, b: 2 })`,
+    `((x: { [:Atom]: :Nothing, a: :Integer }) => :x)({ a: 1, b: 2 })`,
     typeMismatch,
   ],
   [
-    `((x: { [:atom.type]: :nothing.type, a: :integer.type }) => :x)({ a: 1 })`,
+    `((x: { [:Atom]: :Nothing, a: :Integer }) => :x)({ a: 1 })`,
     success({ a: '1' }),
   ],
-  [`{ a: 1 } ~ { [:atom.type]: :atom.type }`, success({ a: '1' })],
-  [`{ a: {} } ~ { [:atom.type]: :atom.type }`, typeMismatch],
+  [`{ a: 1 } ~ { [:Atom]: :Atom }`, success({ a: '1' })],
+  [`{ a: {} } ~ { [:Atom]: :Atom }`, typeMismatch],
   [
-    `{ 1: hello, name: x } ~ { [:natural_number.type]: :atom.type }`,
+    `{ 1: hello, name: x } ~ { [:NaturalNumber]: :Atom }`,
     success({ 1: 'hello', name: 'x' }),
   ],
-  [`{ 1: {}, name: x } ~ { [:natural_number.type]: :atom.type }`, typeMismatch],
+  [`{ 1: {}, name: x } ~ { [:NaturalNumber]: :Atom }`, typeMismatch],
   [
-    `{ 1: hello, name: x } ~ { [:atom.type]: :nothing.type, [:natural_number.type]: :atom.type }`,
+    `{ 1: hello, name: x } ~ { [:Atom]: :Nothing, [:NaturalNumber]: :Atom }`,
     typeMismatch,
   ],
   [
-    `{ 1: hello } ~ { [:atom.type]: :atom.type, [:natural_number.type]: :integer.type }`,
+    `{ 1: hello } ~ { [:Atom]: :Atom, [:NaturalNumber]: :Integer }`,
     typeMismatch,
   ],
   [
-    `{ x: hello } ~ { [:atom.type]: :atom.type, [:natural_number.type]: :integer.type }`,
+    `{ x: hello } ~ { [:Atom]: :Atom, [:NaturalNumber]: :Integer }`,
     success({ x: 'hello' }),
   ],
+  [`{ a: hello } ~ { [a]: :Nothing, a: :Atom }`, success({ a: 'hello' })],
   [
-    `{ a: hello } ~ { [a]: :nothing.type, a: :atom.type }`,
-    success({ a: 'hello' }),
-  ],
-  [
-    `{ a: hello, b: x } ~ { a: :atom.type, [@union { a, b }]: :nothing.type }`,
+    `{ a: hello, b: x } ~ { a: :Atom, [@union { a, b }]: :Nothing }`,
     typeMismatch,
   ],
+  [`{} ~ { [:Atom]: :Atom, [:Atom]: :Nothing }`, success({})],
+  [`{} ~ { [:Atom]: a, [:Atom]: b }`, success({})],
   [
-    `{} ~ { [:atom.type]: :atom.type, [:atom.type]: :nothing.type }`,
-    success({}),
-  ],
-  [`{} ~ { [:atom.type]: a, [:atom.type]: b }`, success({})],
-  [
-    `{ a: 1, b: 2 } ~ @union { 0: { [:atom.type]: :nothing.type, a: :integer.type } }`,
+    `{ a: 1, b: 2 } ~ @union { 0: { [:Atom]: :Nothing, a: :Integer } }`,
     typeMismatch,
   ],
   // Excess clause key types much be a subtype of `atom`.
-  [`(a: { [:something.type]: a }) => _`, typeMismatch],
+  [`(a: { [:Something]: a }) => _`, typeMismatch],
   [`(a: { [{}]: b }) => _`, typeMismatch],
   [
     `{
-      sum: (start_key: :natural_number.type) =>
-        (sequence: { [:natural_number.type]: :integer.type }) =>
+      sum: (start_key: :NaturalNumber) =>
+        (sequence: { [:NaturalNumber]: :Integer }) =>
           :sequence object.lookup :start_key option.map (
-            (value1: :integer.type) =>
+            (value1: :Integer) =>
               :sequence sum (:start_key + 1) match {
-                some: (value2: :integer.type) => :value1 + :value2
+                some: (value2: :Integer) => :value1 + :value2
                 none: _ => :value1
               }
           )
@@ -1177,12 +1171,12 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     `{
-      sum: (start_key: :natural_number.type) =>
-        (sequence: { [:natural_number.type]: :integer.type }) =>
+      sum: (start_key: :NaturalNumber) =>
+        (sequence: { [:NaturalNumber]: :Integer }) =>
           :sequence object.lookup :start_key option.map (
-            (value1: :integer.type) =>
+            (value1: :Integer) =>
               :sequence sum (:start_key + 1) match {
-                some: (value2: :integer.type) => :value1 + :value2
+                some: (value2: :Integer) => :value1 + :value2
                 none: _ => :value1
               }
           )
@@ -1194,8 +1188,8 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     `{
-      even: (n: :integer.type) => @if { :n < 1, true, else: :odd(:n - 1) }
-      odd: (n: :integer.type) => @if { :n < 1, false, else: :even(:n - 1) }
+      even: (n: :Integer) => @if { :n < 1, true, else: :odd(:n - 1) }
+      odd: (n: :Integer) => @if { :n < 1, false, else: :even(:n - 1) }
       results: {
         six: :even(6)
         seven: :even(7)
@@ -1208,4 +1202,19 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       mapped: { tag: 'some', value: 'true' },
     }),
   ],
+
+  // PascalCased names like `:Boolean` are the idiomatic way to name types, but
+  // standard library types are also reachable at `:module.type`.
+  [`hello ~ :atom.type ~ :Atom`, success('hello')],
+  [`(:boolean.not ~ (:boolean.type ~> :Boolean))(false)`, success('true')],
+  [`(1 + 1) ~ :integer.type ~ :Integer`, success('2')],
+  [`42 ~ :natural_number.type ~ :NaturalNumber`, success('42')],
+  [
+    `:option.make_some(1) ~ :option.type(:Integer)`,
+    success({ tag: 'some', value: '1' }),
+  ],
+  [`{ a: 1 } ~ :object.type ~ :Object`, success({ a: '1' })],
+  [`{} ~ :something.type ~ :Something`, success({})],
+  [`{ a: 1 } ~ { [:atom.type]: :Nothing, a: :Integer }`, success({ a: '1' })],
+  [`((a: :atom.type) => :a) ~ (:Atom ~> :Atom)`, assertSuccess],
 ])

--- a/src/language/cli/please.test.ts
+++ b/src/language/cli/please.test.ts
@@ -50,14 +50,14 @@ suite('please CLI error reporting', () => {
   })
 
   test('frames a type mismatch error with an underline', async () => {
-    const { stdout, stderr, code } = await runPlease('1 ~ :boolean.type', [
+    const { stdout, stderr, code } = await runPlease('1 ~ :Boolean', [
       '--no-color',
     ])
     assert.equal(code, 1)
     assert.equal(stdout, '')
     assert.match(stderr, /^Error: /)
     assert.ok(stderr.includes('\n<stdin>:1:1\n'))
-    assert.ok(stderr.includes('\n1 │ 1 ~ :boolean.type\n'))
+    assert.ok(stderr.includes('\n1 │ 1 ~ :Boolean\n'))
     assert.ok(stderr.includes('\n  │ ▔\n'))
   })
 
@@ -68,9 +68,7 @@ suite('please CLI error reporting', () => {
     assert.equal(code, 1)
     assert.equal(stdout, '')
     assert.ok(
-      stderr.startsWith(
-        'Error: argument with type `{ [:atom.type]: :nothing.type }`',
-      ),
+      stderr.startsWith('Error: argument with type `{ [:Atom]: :Nothing }`'),
     )
     assert.ok(stderr.includes('\n<stdin>:1:14\n'))
     assert.ok(stderr.includes('\n1 │ :boolean.not({})\n'))

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -255,7 +255,7 @@ testCases(
   ],
 
   [
-    '@runtime { _ => 42 ~ :integer.type }',
+    '@runtime { _ => 42 ~ :Integer }',
     success({
       '0': '@runtime',
       '1': {
@@ -268,7 +268,7 @@ testCases(
   ],
 
   [
-    '@runtime { _ => { some_integer: 42, same_integer: :some_integer ~ :integer.type } }',
+    '@runtime { _ => { some_integer: 42, same_integer: :some_integer ~ :Integer } }',
     success({
       '0': '@runtime',
       '1': {
@@ -284,7 +284,7 @@ testCases(
   ],
 
   [
-    '@runtime { context => :context.program.start_time ~ :atom.type }',
+    '@runtime { context => :context.program.start_time ~ :Atom }',
     success({
       '0': '@runtime',
       '1': {
@@ -312,7 +312,7 @@ testCases(
   ],
 
   [
-    '@runtime { _ => 42 ~ :boolean.type }',
+    '@runtime { _ => 42 ~ :Boolean }',
     result => {
       assert(either.isLeft(result))
       assert('kind' in result.value)
@@ -321,7 +321,7 @@ testCases(
   ],
 
   [
-    '@runtime { context => :context.program.start_time ~ :object.type }',
+    '@runtime { context => :context.program.start_time ~ :Object }',
     result => {
       assert(either.isLeft(result))
       assert('kind' in result.value)
@@ -330,14 +330,14 @@ testCases(
   ],
 
   [
-    '@runtime { context => { a: :context.program.start_time, :a ~ :atom.type } }',
+    '@runtime { context => { a: :context.program.start_time, :a ~ :Atom } }',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '@runtime { context => :context.program.start_time } ~ :atom.type',
+    '@runtime { context => :context.program.start_time } ~ :Atom',
     success({
       '0': '@runtime',
       '1': {
@@ -365,7 +365,7 @@ testCases(
   ],
 
   [
-    '@runtime { context => :context.program.start_time } ~ :atom.type',
+    '@runtime { context => :context.program.start_time } ~ :Atom',
     success({
       '0': '@runtime',
       '1': {
@@ -393,86 +393,86 @@ testCases(
   ],
 
   [
-    '@runtime { context => { a: :context.program.start_time } ~ { a: :atom.type } }',
+    '@runtime { context => { a: :context.program.start_time } ~ { a: :Atom } }',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '{ a: @runtime { context => :context.program.start_time }, :a ~ :atom.type }',
+    '{ a: @runtime { context => :context.program.start_time }, :a ~ :Atom }',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '@runtime { context => { a: :context.program.start_time, b: :a, :b ~ :atom.type } }',
+    '@runtime { context => { a: :context.program.start_time, b: :a, :b ~ :Atom } }',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '{ a: @runtime { context => :context.program.start_time }, b: :a, :b ~ :atom.type }',
+    '{ a: @runtime { context => :context.program.start_time }, b: :a, :b ~ :Atom }',
     result => {
       assert(either.isRight(result))
     },
   ],
 
-  ['@if { true, true, 42 } ~ :boolean.type', success('true')],
+  ['@if { true, true, 42 } ~ :Boolean', success('true')],
 
   [
-    '{ a: 42, b: :a, @runtime { _ => :b } ~ :integer.type }',
-    result => {
-      assert(either.isRight(result))
-    },
-  ],
-
-  [
-    '{ a: 42, (_ => :a)(@runtime { _ => _ }) ~ :integer.type }',
+    '{ a: 42, b: :a, @runtime { _ => :b } ~ :Integer }',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '{ a: 42, b: _ => :a, c: :b(_) ~ :integer.type }',
+    '{ a: 42, (_ => :a)(@runtime { _ => _ }) ~ :Integer }',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '{ a: 42, b: _ => :a, :b(@runtime { _ => _ }) ~ :integer.type }',
+    '{ a: 42, b: _ => :a, c: :b(_) ~ :Integer }',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '{ a: 42, b: _ => :a }.b(_) ~ :integer.type',
+    '{ a: 42, b: _ => :a, :b(@runtime { _ => _ }) ~ :Integer }',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '{ a: _ => 42, b: :a, :b(@runtime { _ => _ }) ~ :integer.type }',
+    '{ a: 42, b: _ => :a }.b(_) ~ :Integer',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '(_ => 42) ~ (:something.type ~> :integer.type)',
+    '{ a: _ => 42, b: :a, :b(@runtime { _ => _ }) ~ :Integer }',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '(_ => 42) ~ (:something.type ~> :boolean.type)',
+    '(_ => 42) ~ (:Something ~> :Integer)',
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    '(_ => 42) ~ (:Something ~> :Boolean)',
     result => {
       assert(either.isLeft(result))
       assert('kind' in result.value)
@@ -481,28 +481,28 @@ testCases(
   ],
 
   [
-    '{ a: 42, f: _ => :a, @runtime { _ => :f } ~ (:something.type ~> :integer.type) }',
+    '{ a: 42, f: _ => :a, @runtime { _ => :f } ~ (:Something ~> :Integer) }',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '{ a: @if { true, true, 42 }, @runtime { _ => :a } ~ :boolean.type }',
+    '{ a: @if { true, true, 42 }, @runtime { _ => :a } ~ :Boolean }',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '{ a: true, b: 42, @runtime { _ => @if { true, :a, :b } } ~ :boolean.type }',
+    '{ a: true, b: 42, @runtime { _ => @if { true, :a, :b } } ~ :Boolean }',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '@if { @runtime { _ => true }, 1, "not an integer" } ~ :integer.type',
+    '@if { @runtime { _ => true }, 1, "not an integer" } ~ :Integer',
     result => {
       assert(either.isRight(result))
     },
@@ -540,7 +540,7 @@ testCases(
   ],
 
   [
-    `@runtime { _ => :integer.is_greater_than(1)(2) } ~ :boolean.type`,
+    `@runtime { _ => :integer.is_greater_than(1)(2) } ~ :Boolean`,
     result => {
       assert(either.isRight(result))
     },
@@ -602,14 +602,14 @@ testCases(
   ],
 
   [
-    `@runtime { context => (a => :a)(:context.program.start_time) } ~ :atom.type`,
+    `@runtime { context => (a => :a)(:context.program.start_time) } ~ :Atom`,
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    `@runtime { context => (a => :a)(:context.program.start_time) } ~ :integer.type`,
+    `@runtime { context => (a => :a)(:context.program.start_time) } ~ :Integer`,
     result => {
       assert(either.isLeft(result))
       assert('kind' in result.value)
@@ -636,7 +636,7 @@ testCases(
   [
     `{
       integer_identity: @function {
-        parameter: { a: :integer.type }
+        parameter: { a: :Integer }
         body: :a
       }
       :integer_identity("not an integer")
@@ -649,7 +649,7 @@ testCases(
   ],
 
   [
-    `a => :a ~ :boolean.type`,
+    `a => :a ~ :Boolean`,
     result => {
       assert(either.isLeft(result))
       assert('kind' in result.value)
@@ -659,9 +659,9 @@ testCases(
 
   [
     // `:a` is a lookup of an unannotated parameter, so its inferred type is an
-    // unconstrained type parameter, which is not assignable to `:integer.type`.
-    // If the language eventually gains Hindley–Milner-style inference this
-    // program may become valid (and this test case will need updating).
+    // unconstrained type parameter, which is not assignable to `:Integer`. To
+    // allow this program, Please could contextually type functions based on
+    // their usage in `@apply`s.
     `(a => :integer.add(1)(:a))(1)`,
     result => {
       assert(either.isLeft(result))
@@ -677,7 +677,7 @@ testCases(
       }
       then: 42
       else: @panic
-    } ~ :integer.type`,
+    } ~ :Integer`,
     result => {
       assert(either.isRight(result))
     },
@@ -693,7 +693,7 @@ testCases(
   ],
 
   [
-    `@if { @runtime { _ => true }, "not a boolean" ~ :boolean.type, oops }`,
+    `@if { @runtime { _ => true }, "not a boolean" ~ :Boolean, oops }`,
     result => {
       assert(either.isLeft(result))
       assert('kind' in result.value)
@@ -791,11 +791,11 @@ testCases(
     },
   ],
 
-  [`((a: :integer.type) => :a)(42) ~ 42`, success('42')],
+  [`((a: :Integer) => :a)(42) ~ 42`, success('42')],
 
   [
     `{
-      swap: (parameters: { :something.type, :something.type }) =>
+      swap: (parameters: { :Something, :Something }) =>
         { :parameters.1, :parameters.0 }
     }.swap({ a, b }) ~ { b, a }`,
     result => {
@@ -805,7 +805,7 @@ testCases(
 
   [
     `{
-      constrain_function: (f: { a: :atom.type } ~> :atom.type) => :f({ a: hello })
+      constrain_function: (f: { a: :Atom } ~> :Atom) => :f({ a: hello })
       should_use_contextual_type: :constrain_function(x => :x.a)
     }`,
     result => {
@@ -815,7 +815,7 @@ testCases(
 
   [
     `{
-      f: (x: { a: :something.type }) => {}
+      f: (x: { a: :Something }) => {}
       :f({ a: a })
     }`,
     result => {
@@ -825,7 +825,7 @@ testCases(
 
   [
     `{
-      type: :boolean.type
+      type: :Boolean
       f: (x: { a: :type }) => {}
       :f({ a: true })
     }`,
@@ -856,7 +856,7 @@ testCases(
   ],
 
   [
-    `(_ => (f: :atom.type) => :f) ~ (:something.type ~> (:atom.type ~> :atom.type))`,
+    `(_ => (f: :Atom) => :f) ~ (:Something ~> (:Atom ~> :Atom))`,
     result => {
       assert(either.isRight(result))
     },
@@ -864,22 +864,22 @@ testCases(
 
   [
     `(@runtime { _ =>
-      { constrain_function: (f: { a: :atom.type } ~> :atom.type) => :f({ a: hello }) }
-    }).constrain_function(x => :x.a) ~ :atom.type`,
+      { constrain_function: (f: { a: :Atom } ~> :Atom) => :f({ a: hello }) }
+    }).constrain_function(x => :x.a) ~ :Atom`,
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '(_ => 42) ~ ((_: :something.type) => :integer.type)',
+    '(_ => 42) ~ ((_: :Something) => :Integer)',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '(_ => 42) ~ ((_: :something.type) => :boolean.type)',
+    '(_ => 42) ~ ((_: :Something) => :Boolean)',
     result => {
       assert(either.isLeft(result))
       assert('kind' in result.value)
@@ -888,46 +888,46 @@ testCases(
   ],
 
   [
-    '{ a: 42, f: _ => :a, :f ~ ((_: :something.type) => :integer.type) }',
+    '{ a: 42, f: _ => :a, :f ~ ((_: :Something) => :Integer) }',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '((a: :boolean.type) => 42) ~ ((a: :boolean.type) => :integer.type)',
+    '((a: :Boolean) => 42) ~ ((a: :Boolean) => :Integer)',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '((a: :boolean.type) => :a) ~ ((a: :boolean.type) => :boolean.type)',
+    '((a: :Boolean) => :a) ~ ((a: :Boolean) => :Boolean)',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    '((a: :boolean.type) => :boolean.not(:a)) ~ ((a: :boolean.type) => :boolean.type)',
+    '((a: :Boolean) => :boolean.not(:a)) ~ ((a: :Boolean) => :Boolean)',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    ':boolean.not ~ ((a: :boolean.type) => :boolean.type)',
+    ':boolean.not ~ ((a: :Boolean) => :Boolean)',
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    `((x: :atom.type) => @if {
+    `((x: :Atom) => @if {
        @runtime { context => :context.program.start_time atom.equals foo }
        { deeper: :x }
        foo
-     }) ~ ((y: :atom.type) => { deeper: :y })`,
+     }) ~ ((y: :Atom) => { deeper: :y })`,
     result => {
       assert(either.isLeft(result))
       assert.deepEqual(result.value.kind, 'typeMismatch')
@@ -936,9 +936,9 @@ testCases(
 
   [
     `{
-      consume: (g: ((y: :atom.type) => { deeper: :y })) =>
+      consume: (g: ((y: :Atom) => { deeper: :y })) =>
         @runtime { _ => :g(hello).deeper }
-      :consume((x: :atom.type) => @if {
+      :consume((x: :Atom) => @if {
         @runtime { context => :context.program.start_time atom.equals foo }
         { deeper: :x }
         foo
@@ -951,32 +951,32 @@ testCases(
   ],
 
   [
-    `((x: :atom.type) => ({ deeper: :x } | foo)) ~ ((y: :atom.type) => ({ deeper: :y } | foo))`,
+    `((x: :Atom) => ({ deeper: :x } | foo)) ~ ((y: :Atom) => ({ deeper: :y } | foo))`,
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    `((x: :atom.type) => @if {
+    `((x: :Atom) => @if {
        @runtime { context => :context.program.start_time atom.equals foo }
        { deeper: :x }
        foo
-     }) ~ ((y: :atom.type) => ({ deeper: :y } | foo))`,
+     }) ~ ((y: :Atom) => ({ deeper: :y } | foo))`,
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    `(x: :atom.type) => (:x ~ :x)`,
+    `(x: :Atom) => (:x ~ :x)`,
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    `(x: :atom.type) =>
+    `(x: :Atom) =>
       (@if {
          @runtime { context => :context.program.start_time atom.equals foo }
          :x
@@ -988,14 +988,14 @@ testCases(
   ],
 
   [
-    `(x: :atom.type) => (:x ~ (:x | foo))`,
+    `(x: :Atom) => (:x ~ (:x | foo))`,
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    `(x: :natural_number.type) => (:x ~ (:integer.type | foo))`,
+    `(x: :NaturalNumber) => (:x ~ (:Integer | foo))`,
     result => {
       assert(either.isRight(result))
     },
@@ -1029,7 +1029,7 @@ testCases(
   [
     `{
       apply_to_1:
-        (integer_identity: (a: :integer.type) => :a) => :integer_identity(1)
+        (integer_identity: (a: :Integer) => :a) => :integer_identity(1)
     }.apply_to_1(a => :a) ~ 1`,
     result => {
       assert(either.isRight(result))
@@ -1101,7 +1101,7 @@ testCases(
 
   [
     `{
-      f: (x: @hole { name: t, constraint: { assignableTo: :something.type } })
+      f: (x: @hole { name: t, constraint: { assignableTo: :Something } })
         => :x
       :f(42) ~ 42
     }`,
@@ -1154,7 +1154,7 @@ testCases(
 
   [
     `{
-      f: (x: (?b: :atom.type)) => :x
+      f: (x: (?b: :Atom)) => :x
       :f(hello) ~ hello
     }`,
     result => {
@@ -1201,14 +1201,14 @@ testCases(
   ],
 
   [
-    `{ a: :nothing.type }`,
+    `{ a: :Nothing }`,
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    `(x: :nothing.type) => :x`,
+    `(x: :Nothing) => :x`,
     result => {
       assert(either.isRight(result))
     },
@@ -1223,7 +1223,7 @@ testCases(
   ],
 
   [
-    `(x: :nothing.type) => :x.x`,
+    `(x: :Nothing) => :x.x`,
     result => {
       assert(either.isLeft(result))
       assert.deepEqual(result.value.kind, 'typeMismatch')
@@ -1318,7 +1318,7 @@ testCases(
 
   [
     `{
-      not: (a: :boolean.type) => @if { :a, false, true }
+      not: (a: :Boolean) => @if { :a, false, true }
       :not(@runtime { context =>
         :context.program.start_time atom.equals "arbitrary atom"
       }) ~ false
@@ -1360,7 +1360,7 @@ testCases(
 
   [
     `{
-      lookup_within: (object: { a: :something.type }) => :object.a
+      lookup_within: (object: { a: :Something }) => :object.a
       :lookup_within(@runtime { _ => { a: true } }) ~ true
     }`,
     result => {
@@ -1370,7 +1370,7 @@ testCases(
 
   [
     `{
-      not: (a: :boolean.type) => @if { :a, false, true }
+      not: (a: :Boolean) => @if { :a, false, true }
       :not(@runtime { _ => false }) ~ true
     }`,
     result => {
@@ -1432,7 +1432,7 @@ testCases(
 
   [
     `{
-      choose: (c: :boolean.type) => (@if { :c, { x: yes }, { x: no } }).x
+      choose: (c: :Boolean) => (@if { :c, { x: yes }, { x: no } }).x
       :choose(@runtime { _ => true }) ~ yes
     }`,
     result => {
@@ -1442,7 +1442,7 @@ testCases(
 
   [
     `{
-      f: (k: :atom.type) => (@if { :atom.equals(a)(:k), { x: yes }, { x: no } }).x
+      f: (k: :Atom) => (@if { :atom.equals(a)(:k), { x: yes }, { x: no } }).x
       :f(@runtime { _ => a }) ~ yes
     }`,
     result => {
@@ -1474,7 +1474,7 @@ testCases(
 
   [
     `{
-      not: (a: :boolean.type) => @if { :a, false, true }
+      not: (a: :Boolean) => @if { :a, false, true }
       :not(@runtime { _ => false }) ~ false
     }`,
     result => {
@@ -1498,7 +1498,7 @@ testCases(
 
   [
     `{
-      lookup_within: (object: (?o: { a: :something.type })) => :object.a
+      lookup_within: (object: (?o: { a: :Something })) => :object.a
       :lookup_within(@runtime { _ => { a: true } }) ~ true
     }`,
     result => {
@@ -1508,7 +1508,7 @@ testCases(
 
   [
     `{
-      apply_to_true: (f: :something.type ~> :something.type) => :f(true)
+      apply_to_true: (f: :Something ~> :Something) => :f(true)
       :apply_to_true(@runtime { _ => a => :a }) ~ true
     }`,
     result => {
@@ -1518,7 +1518,7 @@ testCases(
 
   [
     `{
-      apply_to_true: (f: :something.type ~> :something.type) => :f(true)
+      apply_to_true: (f: :Something ~> :Something) => :f(true)
       :apply_to_true(@runtime { _ => a => :a }) ~ false
     }`,
     result => {
@@ -1530,7 +1530,7 @@ testCases(
 
   [
     `{
-      apply_to_true: (f: (?g: :something.type ~> :something.type)) => :f(true)
+      apply_to_true: (f: (?g: :Something ~> :Something)) => :f(true)
       :apply_to_true(@runtime { _ => a => :a }) ~ true
     }`,
     result => {
@@ -1540,7 +1540,7 @@ testCases(
 
   [
     `{
-      apply_to_true: (f: (?g: :something.type ~> :something.type)) => :f(true)
+      apply_to_true: (f: (?g: :Something ~> :Something)) => :f(true)
       :apply_to_true(@runtime { _ => a => :a }) ~ false
     }`,
     result => {
@@ -1552,7 +1552,7 @@ testCases(
 
   [
     `{
-      apply_to_true: (f: (?g: :something.type ~> :something.type)) => :f(true)
+      apply_to_true: (f: (?g: :Something ~> :Something)) => :f(true)
       :apply_to_true(@runtime { _ => _ => false }) ~ false
     }`,
     result => {
@@ -1562,9 +1562,9 @@ testCases(
 
   [
     `{
-      apply_to_true: (f: :something.type ~> :something.type) => :f(true)
+      apply_to_true: (f: :Something ~> :Something) => :f(true)
       first: x => _y => :x
-      :apply_to_true(@runtime { _ => :first }) ~ (:something.type ~> true)
+      :apply_to_true(@runtime { _ => :first }) ~ (:Something ~> true)
     }`,
     result => {
       assert(either.isRight(result))
@@ -1573,9 +1573,9 @@ testCases(
 
   [
     `{
-      apply_to_true: (f: :something.type ~> :something.type) => :f(true)
+      apply_to_true: (f: :Something ~> :Something) => :f(true)
       first: x => _y => :x
-      :apply_to_true(@runtime { _ => :first }) ~ (:something.type ~> false)
+      :apply_to_true(@runtime { _ => :first }) ~ (:Something ~> false)
     }`,
     result => {
       assert(either.isLeft(result))
@@ -1586,7 +1586,7 @@ testCases(
 
   [
     `{
-      lookup_foo: (f: :something.type ~> (?b: { foo: :something.type })) => :f(true).foo
+      lookup_foo: (f: :Something ~> (?b: { foo: :Something })) => :f(true).foo
       :lookup_foo(@runtime { _ => _ => { foo: 42 } }) ~ 42
     }`,
     result => {
@@ -1596,7 +1596,7 @@ testCases(
 
   [
     `{
-      lookup_foo: (f: :something.type ~> (?b: { foo: :something.type })) => :f(true).foo
+      lookup_foo: (f: :Something ~> (?b: { foo: :Something })) => :f(true).foo
       :lookup_foo(@runtime { _ => _ => { foo: 42 } }) ~ 43
     }`,
     result => {
@@ -1607,7 +1607,7 @@ testCases(
   ],
 
   [
-    `{ lookup_foo: (f: :something.type ~> (?b: { foo: :something.type })) => :f(true).bar }`,
+    `{ lookup_foo: (f: :Something ~> (?b: { foo: :Something })) => :f(true).bar }`,
     result => {
       assert(either.isLeft(result))
       assert('kind' in result.value)
@@ -1647,7 +1647,7 @@ testCases(
   ],
 
   [
-    `a => (x: (?b: :a)) => (:x ~ :integer.type)`,
+    `a => (x: (?b: :a)) => (:x ~ :Integer)`,
     result => {
       assert(either.isLeft(result))
       assert.deepEqual(result.value.kind, 'typeMismatch')
@@ -1655,7 +1655,7 @@ testCases(
   ],
 
   [
-    `a => (x: (?b: :a)) => (:b ~ :integer.type)`,
+    `a => (x: (?b: :a)) => (:b ~ :Integer)`,
     result => {
       assert(either.isLeft(result))
       assert.deepEqual(result.value.kind, 'typeMismatch')
@@ -1670,7 +1670,7 @@ testCases(
   ],
 
   [
-    `(a: :something.type) => (f: :a ~> :something.type) => :f("an arbitrary value")`,
+    `(a: :Something) => (f: :a ~> :Something) => :f("an arbitrary value")`,
     result => {
       assert(either.isLeft(result))
       assert.deepEqual(result.value.kind, 'typeMismatch')
@@ -1679,8 +1679,8 @@ testCases(
 
   [
     `{
-      example: (a: :something.type) => (f: :a ~> :something.type) => :f("an arbitrary value")
-      result: :example(@runtime { _ => 1 })((n: :integer.type) => :integer.add(1)(:n))
+      example: (a: :Something) => (f: :a ~> :Something) => :f("an arbitrary value")
+      result: :example(@runtime { _ => 1 })((n: :Integer) => :integer.add(1)(:n))
     }`,
     result => {
       assert(either.isLeft(result))
@@ -1705,8 +1705,8 @@ testCases(
   ],
 
   [
-    `(x: { a: :atom.type }) =>
-      ((h: :x.a ~> :atom.type) => :h(forged))((v: :x.a) => :v)`,
+    `(x: { a: :Atom }) =>
+      ((h: :x.a ~> :Atom) => :h(forged))((v: :x.a) => :v)`,
     result => {
       assert(either.isLeft(result))
       assert.deepEqual(result.value.kind, 'typeMismatch')
@@ -1715,10 +1715,10 @@ testCases(
 
   [
     `{
-      caller: (g: { a: :atom.type } ~> :atom.type) =>
+      caller: (g: { a: :Atom } ~> :Atom) =>
         @runtime { _ => :g({ a: actual }) }
       result: :caller(x =>
-        ((h: :x.a ~> :atom.type) => :h(forged))((v: :x.a) => :v))
+        ((h: :x.a ~> :Atom) => :h(forged))((v: :x.a) => :v))
     }`,
     result => {
       assert(either.isLeft(result))
@@ -1728,7 +1728,7 @@ testCases(
 
   [
     `{
-      caller: (g: { a: :atom.type } ~> { got: :atom.type }) =>
+      caller: (g: { a: :Atom } ~> { got: :Atom }) =>
         @runtime { _ => :g({ a: actual }) }
       result: :caller(x =>
         ((h: :x.a ~> { got: :x.a }) => :h(forged))((v: :x.a) => { got: :v }))
@@ -1744,9 +1744,9 @@ testCases(
     // application below to unsoundly succeed because the prior call locked in
     // `:a`'s type as `1`.
     `{
-      call_with: x => (f: :something.type ~> :something.type) => :f(:x)
-      first: :call_with(1)((n: :integer.type) => :n)
-      second: :call_with(a)((n: :integer.type) => :n)
+      call_with: x => (f: :Something ~> :Something) => :f(:x)
+      first: :call_with(1)((n: :Integer) => :n)
+      second: :call_with(a)((n: :Integer) => :n)
     }`,
     result => {
       assert(either.isLeft(result))
@@ -1759,9 +1759,9 @@ testCases(
 
   [
     `{
-      test: (f: (:something.type ~> :integer.type) | (:something.type ~> :boolean.type)) =>
+      test: (f: (:Something ~> :Integer) | (:Something ~> :Boolean)) =>
         :f(_)
-      :test(@runtime { _ => _ => 42 }) ~ :integer.type
+      :test(@runtime { _ => _ => 42 }) ~ :Integer
     }`,
     result => {
       assert(either.isRight(result))
@@ -1770,9 +1770,9 @@ testCases(
 
   [
     `{
-      test: (f: (:something.type ~> :integer.type) | (:something.type ~> :boolean.type)) =>
+      test: (f: (:Something ~> :Integer) | (:Something ~> :Boolean)) =>
         :f(_)
-      :test(@runtime { _ => _ => 42 }) ~ :boolean.type
+      :test(@runtime { _ => _ => 42 }) ~ :Boolean
     }`,
     result => {
       assert(either.isLeft(result))
@@ -1784,7 +1784,7 @@ testCases(
   [
     `{
       apply_natural: (f:
-        (:integer.type ~> :something.type) | (:natural_number.type ~> :something.type)
+        (:Integer ~> :Something) | (:NaturalNumber ~> :Something)
       ) => :f(5)
     }`,
     result => {
@@ -1795,7 +1795,7 @@ testCases(
   [
     `{
       apply_natural: (f:
-        (:integer.type ~> :something.type) | (:natural_number.type ~> :something.type)
+        (:Integer ~> :Something) | (:NaturalNumber ~> :Something)
       ) => :f(-1)
     }`,
     result => {
@@ -1808,15 +1808,15 @@ testCases(
   [
     `{
       test: (object: {
-        a: :integer.type
-        f: :integer.type ~> :something.type
+        a: :Integer
+        f: :Integer ~> :Something
       } | {
-        a: :boolean.type
-        f: :boolean.type ~> :something.type
+        a: :Boolean
+        f: :Boolean ~> :Something
       }) => :object.f(:object.a)
       :test({
         a: @runtime { _ => true }
-        f: (x: :boolean.type) => @if { :x, yes, no }
+        f: (x: :Boolean) => @if { :x, yes, no }
       }) ~ yes
     }`,
     result => {
@@ -1827,15 +1827,15 @@ testCases(
   [
     `{
       test: (object: {
-        a: :integer.type
-        f: :integer.type ~> :something.type
+        a: :Integer
+        f: :Integer ~> :Something
       } | {
-        a: :boolean.type
-        f: :boolean.type ~> :something.type
+        a: :Boolean
+        f: :Boolean ~> :Something
       }) => :object.f(:object.a)
       :test({
         a: @runtime { _ => true }
-        f: (x: :boolean.type) => @if { :x, yes, no }
+        f: (x: :Boolean) => @if { :x, yes, no }
       }) ~ no
     }`,
     result => {
@@ -1848,12 +1848,12 @@ testCases(
   [
     `{
       test: (object: (?o: {
-        a: :boolean.type
-        f: :boolean.type ~> :something.type
+        a: :Boolean
+        f: :Boolean ~> :Something
       })) => :object.f(:object.a)
       :test(@runtime { _ => {
         a: true
-        f: (x: :boolean.type) => @if { :x, yes, no }
+        f: (x: :Boolean) => @if { :x, yes, no }
       }}) ~ yes
     }`,
     result => {
@@ -1864,11 +1864,11 @@ testCases(
   [
     `{
       test: (object: {
-        a: :integer.type
-        f: :boolean.type ~> :something.type
+        a: :Integer
+        f: :Boolean ~> :Something
       } | {
-        a: :boolean.type
-        f: :integer.type ~> :something.type
+        a: :Boolean
+        f: :Integer ~> :Something
       }) => :object.f(:object.a)
     }`,
     result => {
@@ -1881,11 +1881,11 @@ testCases(
   [
     `{
       test: (object: {
-        a: :integer.type
-        f: :integer.type ~> ?x
+        a: :Integer
+        f: :Integer ~> ?x
       } | {
-        a: :boolean.type
-        f: :boolean.type ~> ?y
+        a: :Boolean
+        f: :Boolean ~> ?y
       }) => :object.f(:object.a)
     }`,
     result => {
@@ -1931,8 +1931,8 @@ testCases(
 
   [
     `{
-      add_natural_numbers: (b: :natural_number.type) => (a: :natural_number.type) => :a + :b
-      requires_a_natural_number: (a: :natural_number.type) => :a
+      add_natural_numbers: (b: :NaturalNumber) => (a: :NaturalNumber) => :a + :b
+      requires_a_natural_number: (a: :NaturalNumber) => :a
       :requires_a_natural_number(:add_natural_numbers(@runtime { _ => 1 })(@runtime { _ => 1 }))
     }`,
     result => {
@@ -1942,8 +1942,8 @@ testCases(
 
   [
     `{
-      add_natural_numbers: (b: :natural_number.type) => (a: :natural_number.type) => :a + :b
-      requires_a_natural_number: (a: :natural_number.type) => :a
+      add_natural_numbers: (b: :NaturalNumber) => (a: :NaturalNumber) => :a + :b
+      requires_a_natural_number: (a: :NaturalNumber) => :a
       :requires_a_natural_number(:add_natural_numbers(@runtime { _ => 1 })(@runtime { _ => -1 }))
     }`,
     result => {
@@ -1955,8 +1955,8 @@ testCases(
 
   [
     `{
-      add_natural_numbers: (b: :natural_number.type) => (a: :natural_number.type) => :a + :b
-      requires_a_natural_number: (a: :natural_number.type) => :a
+      add_natural_numbers: (b: :NaturalNumber) => (a: :NaturalNumber) => :a + :b
+      requires_a_natural_number: (a: :NaturalNumber) => :a
       :requires_a_natural_number(:add_natural_numbers(@runtime { _ => -1 })(@runtime { _ => 1 }))
     }`,
     result => {
@@ -1968,8 +1968,8 @@ testCases(
 
   [
     `{
-      subtract_natural_numbers: (b: :natural_number.type) => (a: :natural_number.type) => :a - :b
-      requires_a_natural_number: (a: :natural_number.type) => :a
+      subtract_natural_numbers: (b: :NaturalNumber) => (a: :NaturalNumber) => :a - :b
+      requires_a_natural_number: (a: :NaturalNumber) => :a
       :requires_a_natural_number(:subtract_natural_numbers(@runtime { _ => 2 })(@runtime { _ => 1 }))
     }`,
     result => {
@@ -1981,9 +1981,9 @@ testCases(
 
   [
     `{
-      subtract_natural_numbers: (b: :natural_number.type) => (a: :natural_number.type) => :a + :b
-      requires_a_natural_number: (a: :natural_number.type) => :a
-      illegal: (a: :integer.type) => :requires_a_natural_number(:subtract_natural_numbers(@runtime { _ => 1 })(:a))
+      subtract_natural_numbers: (b: :NaturalNumber) => (a: :NaturalNumber) => :a + :b
+      requires_a_natural_number: (a: :NaturalNumber) => :a
+      illegal: (a: :Integer) => :requires_a_natural_number(:subtract_natural_numbers(@runtime { _ => 1 })(:a))
     }`,
     result => {
       assert(either.isLeft(result))
@@ -1993,35 +1993,35 @@ testCases(
   ],
 
   [
-    `{ increment: (x: :natural_number.type) => (1 + :x) ~ :natural_number.type }`,
+    `{ increment: (x: :NaturalNumber) => (1 + :x) ~ :NaturalNumber }`,
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    `{ increment: (x: :natural_number.type) => (:x + 1) ~ :natural_number.type }`,
+    `{ increment: (x: :NaturalNumber) => (:x + 1) ~ :NaturalNumber }`,
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    `{ double: (x: :natural_number.type) => (2 * :x) ~ :natural_number.type }`,
+    `{ double: (x: :NaturalNumber) => (2 * :x) ~ :NaturalNumber }`,
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    `{ f: (x: :natural_number.type) => ((1 + :x) + :x) ~ :natural_number.type }`,
+    `{ f: (x: :NaturalNumber) => ((1 + :x) + :x) ~ :NaturalNumber }`,
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    `{ decrement: (x: :natural_number.type) => (:x - 1) ~ :natural_number.type }`,
+    `{ decrement: (x: :NaturalNumber) => (:x - 1) ~ :NaturalNumber }`,
     result => {
       assert(either.isLeft(result))
       assert('kind' in result.value)
@@ -2030,7 +2030,7 @@ testCases(
   ],
 
   [
-    `{ increment: (x: :integer.type) => (1 + :x) ~ :natural_number.type }`,
+    `{ increment: (x: :Integer) => (1 + :x) ~ :NaturalNumber }`,
     result => {
       assert(either.isLeft(result))
       assert('kind' in result.value)
@@ -2046,8 +2046,8 @@ testCases(
     // TODO: Enhance the type system and/or the encoding of numbers to enable
     // this sort of reasoning and eliminate the type mismatch from this test.
     `{
-      classify: (n: :integer.type) => @if { :n + 1 < 1, negative, non_negative }
-      narrowed: (m: :natural_number.type) => :classify(:m) ~ non_negative
+      classify: (n: :Integer) => @if { :n + 1 < 1, negative, non_negative }
+      narrowed: (m: :NaturalNumber) => :classify(:m) ~ non_negative
     }`,
     result => {
       assert(either.isLeft(result))
@@ -2057,21 +2057,21 @@ testCases(
   ],
 
   [
-    `{ f: (x: :integer.type) => :integer.is(:x) ~ true }`,
+    `{ f: (x: :Integer) => :integer.is(:x) ~ true }`,
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    `{ f: (x: :natural_number.type) => :integer.is(:x) ~ true }`,
+    `{ f: (x: :NaturalNumber) => :integer.is(:x) ~ true }`,
     result => {
       assert(either.isRight(result))
     },
   ],
 
   [
-    `{ f: (x: :atom.type) => :integer.is(:x) ~ true }`,
+    `{ f: (x: :Atom) => :integer.is(:x) ~ true }`,
     result => {
       assert(either.isLeft(result))
       assert('kind' in result.value)
@@ -2080,7 +2080,7 @@ testCases(
   ],
 
   [
-    `{ f: (x: :something.type) => :something.is(:x) ~ true }`,
+    `{ f: (x: :Something) => :something.is(:x) ~ true }`,
     result => {
       assert(either.isRight(result))
     },
@@ -2088,8 +2088,8 @@ testCases(
 
   [
     `{
-      needs_some: (o: { tag: some, value: :integer.type }) => :o
-      use: (x: :integer.type) => :needs_some(:integer.from(:x))
+      needs_some: (o: { tag: some, value: :Integer }) => :o
+      use: (x: :Integer) => :needs_some(:integer.from(:x))
     }`,
     result => {
       assert(either.isRight(result))
@@ -2102,7 +2102,7 @@ testCases(
         (:integer.from(:a) match {
           some: b => :b
           none: _ => 0
-        }) ~ :integer.type
+        }) ~ :Integer
     }`,
     result => {
       assert(either.isRight(result))
@@ -2115,7 +2115,7 @@ testCases(
         (:integer.from(:a) match {
           some: b => :b
           none: _ => 0
-        }) ~ :natural_number.type
+        }) ~ :NaturalNumber
     }`,
     result => {
       assert(either.isLeft(result))
@@ -2130,7 +2130,7 @@ testCases(
         (:integer.from(:a) match {
           some: _ => true
           none: _ => false
-        }) ~ :boolean.type
+        }) ~ :Boolean
     }`,
     result => {
       assert(either.isRight(result))
@@ -2157,7 +2157,7 @@ testCases(
     `{
       test: a =>
         :integer.from(:a) match {
-          some: (b: :boolean.type) => 1
+          some: (b: :Boolean) => 1
           none: _ => 2
         }
     }`,
@@ -2170,7 +2170,7 @@ testCases(
     // TODO: This should be rejected by static analysis (`:a` may have arbitrary
     // tags).
     `{
-      test: (a: { tag: :atom.type, value: :something.type }) =>
+      test: (a: { tag: :Atom, value: :Something }) =>
         :a match {
           some: _ => 1
           none: _ => 2
@@ -2182,7 +2182,7 @@ testCases(
   ],
 
   [
-    `"-1-1" ~ :integer.type`,
+    `"-1-1" ~ :Integer`,
     result => {
       assert(either.isLeft(result))
       assert.deepEqual(result.value.kind, 'typeMismatch')
@@ -2190,7 +2190,7 @@ testCases(
   ],
 
   [
-    `"00" ~ :natural_number.type`,
+    `"00" ~ :NaturalNumber`,
     result => {
       assert(either.isLeft(result))
       assert.deepEqual(result.value.kind, 'typeMismatch')
@@ -2235,7 +2235,7 @@ testCases(
   ],
 
   [
-    `(_ => x) ~ ((:something.type ~> :atom.type) | (:something.type ~> :atom.type))`,
+    `(_ => x) ~ ((:Something ~> :Atom) | (:Something ~> :Atom))`,
     result => {
       assert(either.isRight(result))
     },
@@ -2302,7 +2302,7 @@ testCases(
   [
     `(
       { a: 1 } object.overlay @runtime { context => { b: :context.program.start_time } }
-    ) ~ { a: 1, b: :atom.type }`,
+    ) ~ { a: 1, b: :Atom }`,
     result => {
       assert(either.isRight(result))
     },
@@ -2319,7 +2319,7 @@ testCases(
   ],
 
   [
-    `({ a: 1 } object.overlay @runtime { context => { b: :context.program.start_time } }) ~ :something.type`,
+    `({ a: 1 } object.overlay @runtime { context => { b: :context.program.start_time } }) ~ :Something`,
     result => {
       assert(either.isRight(result))
     },
@@ -2334,8 +2334,8 @@ testCases(
 
   [
     `{
-      f: (x: :integer.type) =>
-        :object.from_property(a)(:x) ~ { a: :integer.type }
+      f: (x: :Integer) =>
+        :object.from_property(a)(:x) ~ { a: :Integer }
     }`,
     result => {
       assert(either.isRight(result))
@@ -2344,8 +2344,8 @@ testCases(
 
   [
     `{
-      f: (x: :integer.type) =>
-        :object.from_property(a)(:x) ~ { a: :integer.type, b: :integer.type }
+      f: (x: :Integer) =>
+        :object.from_property(a)(:x) ~ { a: :Integer, b: :Integer }
     }`,
     result => {
       assert(either.isLeft(result))
@@ -2355,8 +2355,8 @@ testCases(
 
   [
     `{
-      f: (x: :integer.type) =>
-        :object.overlay({ b: :x })({ a: :x }) ~ { a: :integer.type, b: :integer.type }
+      f: (x: :Integer) =>
+        :object.overlay({ b: :x })({ a: :x }) ~ { a: :Integer, b: :Integer }
     }`,
     result => {
       assert(either.isRight(result))
@@ -2365,8 +2365,8 @@ testCases(
 
   [
     `{
-      f: (x: :integer.type) =>
-        :object.lookup(a)({ a: :x }) ~ { tag: some, value: :integer.type }
+      f: (x: :Integer) =>
+        :object.lookup(a)({ a: :x }) ~ { tag: some, value: :Integer }
     }`,
     result => {
       assert(either.isRight(result))
@@ -2375,7 +2375,7 @@ testCases(
 
   [
     `{
-      f: (x: :integer.type) =>
+      f: (x: :Integer) =>
         :object.lookup(c)({ a: :x }) ~ { tag: none, value: {} }
     }`,
     result => {
@@ -2385,7 +2385,7 @@ testCases(
 
   [
     `{
-      f: (x: :integer.type) =>
+      f: (x: :Integer) =>
         :object.lookup(a)({ a: :x }) ~ { tag: none, value: {} }
     }`,
     result => {
@@ -2396,9 +2396,9 @@ testCases(
 
   [
     `{
-      f: (key: :atom.type) => (x: :integer.type) =>
+      f: (key: :Atom) => (x: :Integer) =>
         :object.lookup(:key)({ a: :x, b: hello }) ~ @union {
-          { tag: some, value: @union { :integer.type, hello } },
+          { tag: some, value: @union { :Integer, hello } },
           { tag: none, value: {} }
         }
     }`,
@@ -2409,8 +2409,8 @@ testCases(
 
   [
     `{
-      f: (key: :atom.type) => (x: :integer.type) =>
-        :object.lookup(:key)({ a: :x }) ~ { tag: some, value: :integer.type }
+      f: (key: :Atom) => (x: :Integer) =>
+        :object.lookup(:key)({ a: :x }) ~ { tag: some, value: :Integer }
     }`,
     result => {
       assert(either.isLeft(result))
@@ -2420,7 +2420,7 @@ testCases(
 
   [
     `{
-      f: (o: { a: hello }) => (key: :atom.type) =>
+      f: (o: { a: hello }) => (key: :Atom) =>
         :object.lookup(:key)(:o) ~ { tag: some, value: hello }
     }`,
     result => {
@@ -2431,9 +2431,9 @@ testCases(
 
   [
     `{
-      f: (key: @union { a, c }) => (x: :integer.type) =>
+      f: (key: @union { a, c }) => (x: :Integer) =>
         :object.lookup(:key)({ a: :x, b: hello }) ~ @union {
-          { tag: some, value: :integer.type },
+          { tag: some, value: :Integer },
           { tag: none, value: {} }
         }
     }`,
@@ -2444,8 +2444,8 @@ testCases(
 
   [
     `{
-      f: (stuff: { inner: { [:atom.type]: :integer.type } }) =>
-        :stuff.inner object.lookup a ~ :option.type(:integer.type)
+      f: (stuff: { inner: { [:Atom]: :Integer } }) =>
+        :stuff.inner object.lookup a ~ :Option(:Integer)
     }`,
     result => {
       assert(either.isRight(result))
@@ -2454,8 +2454,8 @@ testCases(
 
   [
     `{
-      f: (g: :atom.type ~> { [:atom.type]: :integer.type }) => (key: :atom.type) =>
-        :g(:key) object.lookup a ~ :option.type(:integer.type)
+      f: (g: :Atom ~> { [:Atom]: :Integer }) => (key: :Atom) =>
+        :g(:key) object.lookup a ~ :Option(:Integer)
     }`,
     result => {
       assert(either.isRight(result))
@@ -2473,13 +2473,13 @@ testCases(
   ],
 
   [
-    `(key: :natural_number.type) =>
+    `(key: :NaturalNumber) =>
       (stuff: {
-        [:natural_number.type]: :integer.type
+        [:NaturalNumber]: :Integer
       } | {
-        [:natural_number.type]: :boolean.type
+        [:NaturalNumber]: :Boolean
       }) =>
-        :stuff object.lookup :key ~ :option.type(:integer.type | :boolean.type)
+        :stuff object.lookup :key ~ :Option(:Integer | :Boolean)
     `,
     result => {
       assert(either.isRight(result))
@@ -2487,9 +2487,9 @@ testCases(
   ],
 
   [
-    `(key: :integer.type) =>
-      (stuff: { [:integer.type]: :integer.type }) =>
-        :stuff object.lookup :key ~ :option.type(:integer.type)
+    `(key: :Integer) =>
+      (stuff: { [:Integer]: :Integer }) =>
+        :stuff object.lookup :key ~ :Option(:Integer)
     `,
     result => {
       assert(either.isRight(result))

--- a/src/language/compiling/error-messages.test.ts
+++ b/src/language/compiling/error-messages.test.ts
@@ -29,29 +29,29 @@ const assertMessageContains = (source: string, expected: string): void => {
 suite('stuck applications are resolved in error messages', () => {
   test('a partially applied prelude function reports what it produces', () => {
     assertMessageContains(
-      '(x: { a: :integer.type }) => :object.overlay(:x)({ b: true }) ~ { b: true }',
-      '`{ b: :something.type, a: (?"x.a": :integer.type) }`',
+      '(x: { a: :Integer }) => :object.overlay(:x)({ b: true }) ~ { b: true }',
+      '`{ b: :Something, a: (?"x.a": :Integer) }`',
     )
   })
 
   test('nested applications collapse rather than compounding', () => {
     assertMessageContains(
-      '(f: :atom.type ~> :atom.type) => (x: :atom.type) => :f(:f(:f(:f(:x)))) ~ :nothing.type',
-      'inferred to have type `(?"f.#return": :atom.type)`',
+      '(f: :Atom ~> :Atom) => (x: :Atom) => :f(:f(:f(:f(:x)))) ~ :Nothing',
+      'inferred to have type `(?"f.#return": :Atom)`',
     )
   })
 
   test('applications within a stuck projection are resolved', () => {
     assertMessageContains(
-      '(f: :atom.type ~> :integer.type) => (b: :boolean.type) => (x: :atom.type) => @if { :b, then: :f(:x), else: true } ~ :nothing.type',
-      '`{ false: true, true: (?"f.#return": :integer.type) }.((?b: false | true))`',
+      '(f: :Atom ~> :Integer) => (b: :Boolean) => (x: :Atom) => @if { :b, then: :f(:x), else: true } ~ :Nothing',
+      '`{ false: true, true: (?"f.#return": :Integer) }.((?b: false | true))`',
     )
   })
 
   test('applications within a stdlib return type are resolved', () => {
     assertMessageContains(
-      '(f: :atom.type ~> :integer.type) => (x: :atom.type) => :object.overlay({ a: :f(:x) })({ b: true }) ~ :nothing.type',
-      '`{ [:atom.type]: :nothing.type, b: true, a: (?"f.#return": :integer.type) }`',
+      '(f: :Atom ~> :Integer) => (x: :Atom) => :object.overlay({ a: :f(:x) })({ b: true }) ~ :Nothing',
+      '`{ [:Atom]: :Nothing, b: true, a: (?"f.#return": :Integer) }`',
     )
   })
 })
@@ -59,8 +59,8 @@ suite('stuck applications are resolved in error messages', () => {
 suite('the top type is reported as itself', () => {
   test('a union which contains it collapses to it', () => {
     assertMessageContains(
-      '{ recurse: (k: :atom.type) => (:object.lookup(:k)({ a: :recurse, b: true }) ~ :nothing.type) }',
-      'value: :something.type',
+      '{ recurse: (k: :Atom) => (:object.lookup(:k)({ a: :recurse, b: true }) ~ :Nothing) }',
+      'value: :Something',
     )
   })
 })
@@ -68,19 +68,19 @@ suite('the top type is reported as itself', () => {
 suite('type parameters survive in error messages', () => {
   test('a signature requiring two positions to agree keeps saying so', () => {
     assertMessageContains(
-      '((f: ?a ~> :a) => :f)((x: :integer.type) => true)',
+      '((f: ?a ~> :a) => :f)((x: :Integer) => true)',
       'parameter type `?a ~> :a`',
     )
   })
 
   test('a parameter shared between properties keeps its identity', () => {
     assertMessageContains(
-      '(x: ?t) => { first: :x, second: :x } ~ { first: :integer.type, second: :atom.type }',
+      '(x: ?t) => { first: :x, second: :x } ~ { first: :Integer, second: :Atom }',
       'first: ?t, second: :t',
     )
   })
 
   test('an unannotated parameter is not reported as the top type', () => {
-    assertMessageContains('a => :a ~ :integer.type', 'have type `?a`')
+    assertMessageContains('a => :a ~ :Integer', 'have type `?a`')
   })
 })

--- a/src/language/compiling/error-spans.test.ts
+++ b/src/language/compiling/error-spans.test.ts
@@ -30,7 +30,7 @@ suite('compile attaches source spans to elaboration errors', () => {
   })
 
   test('type mismatch blames the checked value', () => {
-    const source = '{} ~ :boolean.type'
+    const source = '{} ~ :Boolean'
     assert.deepEqual(compileErrorSpan(source), [0, 2])
     assert.equal(source.slice(0, 2), '{}')
   })
@@ -60,21 +60,21 @@ suite('compile attaches source spans to elaboration errors', () => {
   })
 
   test('a check on an infix expression blames the whole expression', () => {
-    const source = '1 + 1 ~ :object.type'
+    const source = '1 + 1 ~ :Object'
     assert.deepEqual(compileErrorSpan(source), [0, 5])
     assert.equal(source.slice(0, 5), '1 + 1')
   })
 
   test('a check trailing a function body blames the body', () => {
-    const source = '(stuff: {}) => :stuff object.lookup a ~ :integer.type'
+    const source = '(stuff: {}) => :stuff object.lookup a ~ :Integer'
     assert.deepEqual(compileErrorSpan(source), [15, 37])
     assert.equal(source.slice(15, 37), ':stuff object.lookup a')
   })
 
   test('an invalid parameter annotation blames the annotation', () => {
-    const source = '(a: { [:something.type]: a }) => :a object.lookup a'
-    assert.deepEqual(compileErrorSpan(source), [4, 28])
-    assert.equal(source.slice(4, 28), '{ [:something.type]: a }')
+    const source = '(a: { [:Something]: a }) => :a object.lookup a'
+    assert.deepEqual(compileErrorSpan(source), [4, 23])
+    assert.equal(source.slice(4, 23), '{ [:Something]: a }')
   })
 
   test('omits the span when compiled with no spans', () => {

--- a/src/language/compiling/parsing.test.ts
+++ b/src/language/compiling/parsing.test.ts
@@ -104,7 +104,7 @@ testCases(parse, input => `parsing \`${input}\``)('parsing', [
   ],
 
   [
-    '(a: :integer.type) => :a',
+    '(a: :Integer) => :a',
     either.makeRight(
       syntaxTree([
         ['0', '@function'],
@@ -117,20 +117,8 @@ testCases(parse, input => `parsing \`${input}\``)('parsing', [
                 [
                   'a',
                   [
-                    ['0', '@index'],
-                    [
-                      '1',
-                      [
-                        [
-                          'object',
-                          [
-                            ['0', '@lookup'],
-                            ['1', [['key', 'integer']]],
-                          ],
-                        ],
-                        ['query', [['0', 'type']]],
-                      ],
-                    ],
+                    ['0', '@lookup'],
+                    ['1', [['key', 'Integer']]],
                   ],
                 ],
               ],
@@ -264,7 +252,7 @@ testCases(parse, input => `parsing \`${input}\``)('parsing', [
   ],
 
   [
-    ':a ~ :integer.type',
+    ':a ~ :Integer',
     either.makeRight(
       syntaxTree([
         ['0', '@check'],
@@ -281,20 +269,8 @@ testCases(parse, input => `parsing \`${input}\``)('parsing', [
             [
               'type',
               [
-                ['0', '@index'],
-                [
-                  '1',
-                  [
-                    [
-                      'object',
-                      [
-                        ['0', '@lookup'],
-                        ['1', [['key', 'integer']]],
-                      ],
-                    ],
-                    ['query', [['0', 'type']]],
-                  ],
-                ],
+                ['0', '@lookup'],
+                ['1', [['key', 'Integer']]],
               ],
             ],
           ],
@@ -396,20 +372,8 @@ testCases(parse, input => `parsing \`${input}\``)('parsing', [
                 [
                   'assignableTo',
                   [
-                    ['0', '@index'],
-                    [
-                      '1',
-                      [
-                        [
-                          'object',
-                          [
-                            ['0', '@lookup'],
-                            ['1', [['key', 'something']]],
-                          ],
-                        ],
-                        ['query', [['0', 'type']]],
-                      ],
-                    ],
+                    ['0', '@lookup'],
+                    ['1', [['key', 'Something']]],
                   ],
                 ],
               ],
@@ -421,7 +385,7 @@ testCases(parse, input => `parsing \`${input}\``)('parsing', [
   ],
 
   [
-    '(?a: :atom.type)',
+    '(?a: :Atom)',
     either.makeRight(
       syntaxTree([
         ['0', '@hole'],
@@ -435,20 +399,8 @@ testCases(parse, input => `parsing \`${input}\``)('parsing', [
                 [
                   'assignableTo',
                   [
-                    ['0', '@index'],
-                    [
-                      '1',
-                      [
-                        [
-                          'object',
-                          [
-                            ['0', '@lookup'],
-                            ['1', [['key', 'atom']]],
-                          ],
-                        ],
-                        ['query', [['0', 'type']]],
-                      ],
-                    ],
+                    ['0', '@lookup'],
+                    ['1', [['key', 'Atom']]],
                   ],
                 ],
               ],
@@ -460,67 +412,63 @@ testCases(parse, input => `parsing \`${input}\``)('parsing', [
   ],
 
   [
-    '{ [:atom.type]: :atom.type }',
+    '{ [:Atom]: :Atom }',
+    result => {
+      assert.deepEqual(
+        result,
+        parse('@object { properties: {}, excess: { 0: { :Atom, :Atom } } }'),
+      )
+    },
+  ],
+  [
+    '{ [:Atom]: :Atom, a: 1 }',
     result => {
       assert.deepEqual(
         result,
         parse(
-          '@object { properties: {}, excess: { 0: { :atom.type, :atom.type } } }',
+          '@object { properties: { a: 1 }, excess: { 0: { :Atom, :Atom } } }',
         ),
       )
     },
   ],
   [
-    '{ [:atom.type]: :atom.type, a: 1 }',
+    '{ [:Atom]: :Something, [:NaturalNumber]: :Atom }',
     result => {
       assert.deepEqual(
         result,
         parse(
-          '@object { properties: { a: 1 }, excess: { 0: { :atom.type, :atom.type } } }',
+          '@object { properties: {}, excess: { 0: { :Atom, :Something }, 1: { :NaturalNumber, :Atom } } }',
         ),
       )
     },
   ],
   [
-    '{ [:atom.type]: :something.type, [:natural_number.type]: :atom.type }',
+    '{ a, [:Atom]: :Atom, b }',
     result => {
       assert.deepEqual(
         result,
         parse(
-          '@object { properties: {}, excess: { 0: { :atom.type, :something.type }, 1: { :natural_number.type, :atom.type } } }',
+          '@object { properties: { a, b }, excess: { 0: { :Atom, :Atom } } }',
         ),
       )
     },
   ],
   [
-    '{ a, [:atom.type]: :atom.type, b }',
+    '@if { [:Atom]: x }',
     result => {
       assert.deepEqual(
         result,
-        parse(
-          '@object { properties: { a, b }, excess: { 0: { :atom.type, :atom.type } } }',
-        ),
+        parse('@if (@object { properties: {}, excess: { 0: { :Atom, x } } })'),
       )
     },
   ],
   [
-    '@if { [:atom.type]: x }',
+    '{ [:Atom]: a, [:Atom]: b }',
     result => {
       assert.deepEqual(
         result,
         parse(
-          '@if (@object { properties: {}, excess: { 0: { :atom.type, x } } })',
-        ),
-      )
-    },
-  ],
-  [
-    '{ [:atom.type]: a, [:atom.type]: b }',
-    result => {
-      assert.deepEqual(
-        result,
-        parse(
-          '@object { properties: {}, excess: { 0: { :atom.type, a }, 1: { :atom.type, b } } }',
+          '@object { properties: {}, excess: { 0: { :Atom, a }, 1: { :Atom, b } } }',
         ),
       )
     },

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.test.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.test.ts
@@ -383,7 +383,7 @@ elaborationSuite('@apply', [
 ])
 
 const stuckApplication =
-  '{ f: (n: :integer.type) => :n, x: @runtime { _context => 1 }, main: :f(:x) }'
+  '{ f: (n: :Integer) => :n, x: @runtime { _context => 1 }, main: :f(:x) }'
 
 const valueAtKeyPath = (
   value: Atom | Molecule,

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -80,11 +80,11 @@ const checkArgumentType = (
  *
  * ```plz
  * (object: {
- *   a: :integer.type
- *   f: :integer.type ~> :something.type
+ *   a: :Integer
+ *   f: :Integer ~> :Something
  * } | {
- *   a: :boolean.type
- *   f: :boolean.type ~> :something.type
+ *   a: :Boolean
+ *   f: :Boolean ~> :Something
  * }) => :object.f(:object.a)
  * ```
  *

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.test.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.test.ts
@@ -153,7 +153,7 @@ const elaborateWithApplicationsInFlight = ({
     }),
   )
 
-const programApplyingF = '{ f: (n: :integer.type) => :n, main: :f(1) }'
+const programApplyingF = '{ f: (n: :Integer) => :n, main: :f(1) }'
 const arbitraryFunctionExpression = makeFunctionExpression('_', '_')
 
 /** Applications of functions other than the one under test. */
@@ -229,7 +229,7 @@ testCases(
 
   [
     {
-      program: '{ f: (n: :integer.type) => :f(:n), main: :f(1) }',
+      program: '{ f: (n: :Integer) => :f(:n), main: :f(1) }',
       description: 'with a demanded budget of 3',
       applicationChain: [],
       configuration: {

--- a/src/language/compiling/semantics/keyword-handlers/lookup-handler.test.ts
+++ b/src/language/compiling/semantics/keyword-handlers/lookup-handler.test.ts
@@ -111,7 +111,7 @@ const compileSuite = testCases(
 
 compileSuite('self-referential lookups', [
   [
-    '{ f: (n: :integer.type) => :f(:n) }',
+    '{ f: (n: :Integer) => :f(:n) }',
     output => {
       assert(either.isRight(output))
       assert.deepEqual(
@@ -123,7 +123,7 @@ compileSuite('self-referential lookups', [
   ],
 
   [
-    '{ helper: 1, f: (x: :integer.type) => :helper }',
+    '{ helper: 1, f: (x: :Integer) => :helper }',
     output => {
       assert(either.isRight(output))
       assert(
@@ -142,7 +142,7 @@ const compileAndRun = testCases(
 compileAndRun('types of self-referential lookups', [
   [
     `{
-      f: (n: :integer.type) => @if { :n < 1, then: 0, else: 1 + :f(:n - 1) }
+      f: (n: :Integer) => @if { :n < 1, then: 0, else: 1 + :f(:n - 1) }
       main: :f(3)
     }.main`,
     output => {
@@ -154,7 +154,7 @@ compileAndRun('types of self-referential lookups', [
 
 compileAndRun('unbounded recursion within a self-referential function', [
   [
-    '{ f: (n: :integer.type) => :f(1), main: :f(0) }.main',
+    '{ f: (n: :Integer) => :f(1), main: :f(0) }.main',
     output => {
       assert(either.isLeft(output))
       assert('kind' in output.value)

--- a/src/language/parsing/expression.ts
+++ b/src/language/parsing/expression.ts
@@ -499,8 +499,8 @@ const compactExpression: Parser<SpannedTree> = recordSpan(
 // ~> a
 // ~> {}
 // ~> (1 ~> true ~> {})
-// ~> :boolean.type ~> :boolean.type ~> :boolean.type
-// ~> :integer.type
+// ~> :Boolean ~> :Boolean ~> :Boolean
+// ~> :Integer
 const trailingSignatureTokens = map(
   sequence([
     trivia,
@@ -520,7 +520,7 @@ const trailingSignatureTokens = map(
 
 // | a
 // | 1 | true | {}
-// | :boolean.type | :integer.type | a
+// | :Boolean | :Integer | a
 const trailingUnionTokens = map(
   sequence([
     trivia,
@@ -557,7 +557,7 @@ const trailingUnionTokens = map(
 
 // ~ a
 // ~ {}
-// ~ (:boolean.type | :integer.type)
+// ~ (:Boolean | :Integer)
 // ~ (a ~> b)
 const trailingCheckToken = map(
   sequence([trivia, tilde, trivia, compactExpression]),
@@ -612,7 +612,7 @@ const trailingInfixTokens = oneOrMore(
   ),
 )
 
-// (a: :integer.type) => :a + 1
+// (a: :Integer) => :a + 1
 const typedFunctionParameter: Parser<SpannedMolecule> = surroundedByParentheses(
   map(
     sequence([
@@ -637,8 +637,8 @@ const functionParameter: Parser<SpannedTree> = oneOf([
 // a => (b => c => :d)
 // a => b => c => d
 // a => 1 + 1
-// (a: :integer.type) => :a + 1
-// (a: :integer.type) => (b: :integer.type) => :a + :b
+// (a: :Integer) => :a + 1
+// (a: :Integer) => (b: :Integer) => :a + :b
 const precededByAtomThenFunctionArrow = map(
   sequence([
     functionParameter,
@@ -757,22 +757,10 @@ const precededByOpeningBrace = map(
     ),
 )
 
-/** `:something.type` in desugared form. */
+/** `:Something` in desugared form. */
 const topTypeAsMolecule = syntheticMolecule([
-  ['0', syntheticAtom('@index')],
-  [
-    '1',
-    syntheticMolecule([
-      [
-        'object',
-        syntheticMolecule([
-          ['0', syntheticAtom('@lookup')],
-          ['1', syntheticMolecule([['key', syntheticAtom('something')]])],
-        ]),
-      ],
-      ['query', syntheticMolecule([['0', syntheticAtom('type')]])],
-    ]),
-  ],
+  ['0', syntheticAtom('@lookup')],
+  ['1', syntheticMolecule([['key', syntheticAtom('Something')]])],
 ])
 
 const makeHoleMolecule = (

--- a/src/language/semantics/expressions/object-type-expression.ts
+++ b/src/language/semantics/expressions/object-type-expression.ts
@@ -20,8 +20,8 @@ export type ObjectTypeExpression = ObjectNode & {
      * @object {
      *   properties: …
      *   excess: {
-     *     { :atom.type, :integer.type }
-     *     { :natural_number.type, :boolean.type }
+     *     { :Atom, :Integer }
+     *     { :NaturalNumber, :Boolean }
      *   }
      * }
      * ```

--- a/src/language/semantics/prelude.ts
+++ b/src/language/semantics/prelude.ts
@@ -20,6 +20,15 @@ export const prelude = makeObjectNode({
   object: makeObjectNode(object),
   something: makeObjectNode(something),
 
+  Atom: atom.type,
+  Option: option.type,
+  Boolean: boolean.type,
+  Integer: integer.type,
+  NaturalNumber: natural_number.type,
+  Nothing: nothing.type,
+  Object: object.type,
+  Something: something.type,
+
   // Aliases:
   '>>': globalFunctions.flow,
   '|>': globalFunctions.identity,

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -433,21 +433,20 @@ export const stringifyResolvedTypeForEndUser = (type: Type): string =>
   stringifyTypeForEndUser(withStuckApplicationsResolved(type))
 
 export const typeSymbolToSemanticGraph = (typeSymbol: TypeSymbol): ObjectNode =>
-  makeIndexExpression({
-    query: objectNodeFromOrderedEntries([['0', 'type']]),
-    object: (() => {
+  makeLookupExpression(
+    (() => {
       switch (typeSymbol) {
         case atomTypeSymbol:
-          return makeLookupExpression('atom')
+          return 'Atom'
         case integerTypeSymbol:
-          return makeLookupExpression('integer')
+          return 'Integer'
         case naturalNumberTypeSymbol:
-          return makeLookupExpression('natural_number')
+          return 'NaturalNumber'
         case somethingTypeSymbol:
-          return makeLookupExpression('something')
+          return 'Something'
       }
     })(),
-  })
+  )
 
 const syntaxTreeToSemanticGraph = (
   syntaxTree: Atom | Molecule,

--- a/src/language/semantics/stdlib/return-type-refiners.ts
+++ b/src/language/semantics/stdlib/return-type-refiners.ts
@@ -27,7 +27,7 @@ export const closedOver =
 /**
  * Builds a `computeRefinedReturnType` function for an `is`-style predicate:
  * when the argument type is assignable to `target` the result is necessarily
- * the literal `true`, otherwise it stays `:boolean.type`.
+ * the literal `true`, otherwise it stays `:Boolean`.
  */
 export const computeIsReturnType =
   (target: Type) =>

--- a/src/language/semantics/stdlib/stdlib-utilities.test.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.test.ts
@@ -112,8 +112,8 @@ const compileAndRun = testCases(
 compileAndRun('recursion through host-implemented functions', [
   [
     `{
-      f: (n: :integer.type) =>
-        :option.make_some(42) option.map ((m: :integer.type) => :f(:m))
+      f: (n: :Integer) =>
+        :option.make_some(42) option.map ((m: :Integer) => :f(:m))
       main: :f(0)
     }.main`,
     output => {
@@ -126,8 +126,8 @@ compileAndRun('recursion through host-implemented functions', [
 
   [
     `{
-      f: (n: :integer.type) => :option.make_some(42) match {
-        some: (m: :integer.type) => :f(:m)
+      f: (n: :Integer) => :option.make_some(42) match {
+        some: (m: :Integer) => :f(:m)
         none: _ => 0
       }
       main: :f(0)
@@ -142,8 +142,8 @@ compileAndRun('recursion through host-implemented functions', [
 
   [
     `{
-      f: (n: :integer.type) =>
-        :option.make_some(42) option.map ((m: :integer.type) => :f(:m))
+      f: (n: :Integer) =>
+        :option.make_some(42) option.map ((m: :Integer) => :f(:m))
     }`,
     output => {
       assert(either.isRight(output))

--- a/src/language/semantics/type-system/genericize-function-parameter.ts
+++ b/src/language/semantics/type-system/genericize-function-parameter.ts
@@ -22,7 +22,7 @@ export type GenericizedFunctionParameterAnnotation = {
  * make functions implicitly generic, even when annotated. For example:
  *
  * ```plz
- * ((x: { a: :integer.type }) => :x.a)({ a: 42 }) ~ 42
+ * ((x: { a: :Integer }) => :x.a)({ a: 42 }) ~ 42
  * ```
  */
 export const genericizeFunctionParameterAnnotation = (
@@ -71,7 +71,7 @@ const genericizeFunctionParameterAnnotationAtKeyPath = (
     object: type => {
       if (Object.keys(type.children).length === 0) {
         // Treat empty object types as leaves to make sure that functions like
-        // `(a: :object.type) => :a` are genericized.
+        // `(a: :Object) => :a` are genericized.
         return genericizeLeaf(
           parameterName,
           keyPath,

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -153,7 +153,7 @@ testCases(
         a: makeUnionType(['c']),
       }),
     ]),
-    ':atom.type | { a: a | b | c }',
+    ':Atom | { a: a | b | c }',
   ],
   [
     // Members whose excess bounds disagree must not merge with each other.
@@ -166,7 +166,7 @@ testCases(
       ]),
       makeObjectType({ a: makeUnionType(['c']) }),
     ]),
-    '{ [:atom.type]: :nothing.type, a: a | b } | { a: c }',
+    '{ [:Atom]: :Nothing, a: a | b } | { a: c }',
   ],
 ])
 typeAssignabilitySuite('prelude types (assignable)', [
@@ -685,7 +685,7 @@ typeAssignabilitySuite('custom types (assignable)', [
   ],
   [
     [
-      // `:atom.type ~> a | :atom.type ~> b` is assignable to `a ~> a | b`
+      // `:Atom ~> a | :Atom ~> b` is assignable to `a ~> a | b`
       makeUnionType([
         makeFunctionType({
           parameter: atom,
@@ -1217,7 +1217,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
   ],
   [
     [
-      // `?a ~> :a` is assignable to `(?a: :atom.type) ~> a`
+      // `?a ~> :a` is assignable to `(?a: :Atom) ~> a`
       makeFunctionType({
         parameter: A,
         return: A,
@@ -1231,7 +1231,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
   ],
   [
     [
-      // `?a ~> :a` is assignable to `:atom.type ~> :atom.type`
+      // `?a ~> :a` is assignable to `:Atom ~> :Atom`
       makeFunctionType({
         parameter: A,
         return: A,
@@ -1245,7 +1245,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
   ],
   [
     [
-      // `(?a: :atom.type) ~> :a` is assignable to `:atom.type ~> :something.type`
+      // `(?a: :Atom) ~> :a` is assignable to `:Atom ~> :Something`
       makeFunctionType({
         parameter: extendsAnyAtom,
         return: extendsAnyAtom,
@@ -1259,7 +1259,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
   ],
   [
     [
-      // `(?a: :atom.type) ~> { a: :a }` is assignable to `:atom.type ~> :something.type`
+      // `(?a: :Atom) ~> { a: :a }` is assignable to `:Atom ~> :Something`
       makeFunctionType({
         parameter: extendsAnyAtom,
         return: makeObjectType({ a: extendsAnyAtom }),
@@ -1273,7 +1273,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
   ],
   [
     [
-      // `?a ~> { a: :a, b: :atom.type }` is assignable to `(?a: :atom.type) ~> { a: a }`
+      // `?a ~> { a: :a, b: :Atom }` is assignable to `(?a: :Atom) ~> { a: a }`
       makeFunctionType({
         parameter: A,
         return: makeObjectType({
@@ -1290,7 +1290,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
   ],
   [
     [
-      // `(?a: :atom.type) ~> { a: :a }` is assignable to `:atom.type ~> { a: :atom.type }`
+      // `(?a: :Atom) ~> { a: :a }` is assignable to `:Atom ~> { a: :Atom }`
       makeFunctionType({
         parameter: extendsAnyAtom,
         return: makeObjectType({ a: extendsAnyAtom }),
@@ -1304,7 +1304,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
   ],
   [
     [
-      // `{ a: ?a } ~> :a` is assignable to `{ a: (?a: :atom.type) } ~> :a`
+      // `{ a: ?a } ~> :a` is assignable to `{ a: (?a: :Atom) } ~> :a`
       makeFunctionType({
         parameter: makeObjectType({
           a: A,
@@ -1322,7 +1322,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
   ],
   [
     [
-      // `{ a: a } ~> { b: a }` is assignable to `{ a: (?a: :atom.type) } ~> { b: a }`
+      // `{ a: a } ~> { b: a }` is assignable to `{ a: (?a: :Atom) } ~> { b: a }`
       makeFunctionType({
         parameter: makeObjectType({
           a: A,
@@ -1344,7 +1344,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
   ],
   [
     [
-      // `((?a: :atom.type) | {}) ~> (:a | z)` is assignable to `(?a: (a | b)) ~> (:a | y | z)`
+      // `((?a: :Atom) | {}) ~> (:a | z)` is assignable to `(?a: (a | b)) ~> (:a | y | z)`
       makeFunctionType({
         parameter: makeUnionType([extendsAnyAtom, object]),
         return: makeUnionType([extendsAnyAtom, 'z']),
@@ -1358,7 +1358,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
   ],
   [
     [
-      // `(?a: (:atom.type ~> :something.type)) ~> :a` is assignable to `(?b: (:something.type ~> :atom.type)) ~> :b`
+      // `(?a: (:Atom ~> :Something)) ~> :a` is assignable to `(?b: (:Something ~> :Atom)) ~> :b`
       makeFunctionType({
         parameter: extendsFunctionFromAtomToValue,
         return: extendsFunctionFromAtomToValue,
@@ -1373,7 +1373,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
 
   [
     [
-      // `(?a: (:atom.type ~> :something.type)) ~> :a` is assignable to `(:something.type ~> :something.type) ~> (:something.type ~> :something.type)`
+      // `(?a: (:Atom ~> :Something)) ~> :a` is assignable to `(:Something ~> :Something) ~> (:Something ~> :Something)`
       makeFunctionType({
         parameter: extendsFunctionFromAtomToValue,
         return: extendsFunctionFromAtomToValue,
@@ -1393,7 +1393,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
   ],
   [
     [
-      // `?a ~> { 0: :a, 1: :a }` is assignable to `(?a: :atom.type) ~> { 0: :a, 1: :atom.type }`
+      // `?a ~> { 0: :a, 1: :a }` is assignable to `(?a: :Atom) ~> { 0: :a, 1: :Atom }`
       makeFunctionType({
         parameter: A,
         return: makeObjectType({
@@ -1439,7 +1439,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
   ],
   [
     [
-      // `{ 0: ?a, 1: ?b } ~> { 0: :b, 1: :a }` is assignable to `{ 0: (?a: :atom.type), 1: (?b: a) } ~> { 0: :b, 1: ?a }`
+      // `{ 0: ?a, 1: ?b } ~> { 0: :b, 1: :a }` is assignable to `{ 0: (?a: :Atom), 1: (?b: a) } ~> { 0: :b, 1: ?a }`
       makeFunctionType({
         parameter: makeObjectType({
           0: A,
@@ -1491,7 +1491,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
   ],
   [
     [
-      // `{ a: ?a, b: ?b, c: :atom.type | :b } ~> { b: :a, a: :b, c: :a }` is assignable to `{ a: (?a: :atom.type), b: (?b: :a), c: :b } ~> { b: :a, a: :b | :a, c: :atom.type }`
+      // `{ a: ?a, b: ?b, c: :Atom | :b } ~> { b: :a, a: :b, c: :a }` is assignable to `{ a: (?a: :Atom), b: (?b: :a), c: :b } ~> { b: :a, a: :b | :a, c: :Atom }`
       makeFunctionType({
         parameter: makeObjectType({
           a: A,
@@ -1524,7 +1524,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
 typeAssignabilitySuite('generic function types (not assignable)', [
   [
     [
-      // `(?a: :atom.type) ~> :a` is not assignable to `:object.type ~> :object.type`
+      // `(?a: :Atom) ~> :a` is not assignable to `:Object ~> :Object`
       makeFunctionType({
         parameter: extendsAnyAtom,
         return: extendsAnyAtom,
@@ -1538,7 +1538,7 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   ],
   [
     [
-      // `(?a: a) ~> :a` is not assignable to `:atom.type ~> :atom.type`
+      // `(?a: a) ~> :a` is not assignable to `:Atom ~> :Atom`
       makeFunctionType({
         parameter: extendsSpecificAtom,
         return: extendsSpecificAtom,
@@ -1552,7 +1552,7 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   ],
   [
     [
-      // `(?a: :atom.type) ~> :a` is not assignable to `?a ~> :a`
+      // `(?a: :Atom) ~> :a` is not assignable to `?a ~> :a`
       makeFunctionType({
         parameter: extendsAnyAtom,
         return: extendsAnyAtom,
@@ -1566,7 +1566,7 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   ],
   [
     [
-      // `?a ~> :a` is not assignable to `:something.type ~> :atom.type`
+      // `?a ~> :a` is not assignable to `:Something ~> :Atom`
       makeFunctionType({
         parameter: A,
         return: A,
@@ -1594,7 +1594,7 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   ],
   [
     [
-      // `((?a: :atom.type) | {}) ~> (:a | z)` is not assignable to `(?a: :atom.type) ~> :a`
+      // `((?a: :Atom) | {}) ~> (:a | z)` is not assignable to `(?a: :Atom) ~> :a`
       makeFunctionType({
         parameter: makeUnionType([extendsAnyAtom, object]),
         return: makeUnionType([extendsAnyAtom, 'z']),
@@ -1634,7 +1634,7 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   ],
   [
     [
-      // `(?a: (:something.type ~> :atom.type)) ~> :a` is not assignable to `((?b: :atom.type) ~> :something.type) ~> :b`
+      // `(?a: (:Something ~> :Atom)) ~> :a` is not assignable to `((?b: :Atom) ~> :Something) ~> :b`
       makeFunctionType({
         parameter: extendsFunctionFromValueToAtom,
         return: extendsFunctionFromValueToAtom,
@@ -1648,7 +1648,7 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   ],
   [
     [
-      // `?a ~> :a` is not assignable to `(:something.type ~> :something.type) ~> :atom.type
+      // `?a ~> :a` is not assignable to `(:Something ~> :Something) ~> :Atom
       makeFunctionType({
         parameter: A,
         return: A,
@@ -1702,17 +1702,17 @@ typeAssignabilitySuite('generic function types (not assignable)', [
 ])
 
 typeAssignabilitySuite('union to type parameter (assignable)', [
-  // `?a | :nothing.type` is assignable to `?a`
+  // `?a | :Nothing` is assignable to `?a`
   [[makeUnionType([A]), A], true],
   // `?a | :a` is assignable to `?a`
   [[makeUnionType([A, A]), A], true],
-  // `?a | :nothing.type` is assignable to `?a | :a`
+  // `?a | :Nothing` is assignable to `?a | :a`
   [[makeUnionType([A]), makeUnionType([A, A])], true],
   // `?a | :a` is assignable to `?a | :a`
   [[makeUnionType([A, A]), makeUnionType([A, A])], true],
-  // `?a | :nothing.type` is assignable to `?a | ?b`
+  // `?a | :Nothing` is assignable to `?a | ?b`
   [[makeUnionType([A]), makeUnionType([A, B])], true],
-  // `(?a: :atom.type) | :nothing.type` is assignable to `(?a: :atom.type)`
+  // `(?a: :Atom) | :Nothing` is assignable to `(?a: :Atom)`
   [[makeUnionType([extendsAnyAtom]), extendsAnyAtom], true],
 ])
 
@@ -1740,17 +1740,17 @@ typeAssignabilitySuite(
 )
 
 typeAssignabilitySuite('union to type parameter (not assignable)', [
-  // `1 | :nothing.type` is not assignable to `?a`
+  // `1 | :Nothing` is not assignable to `?a`
   [[makeUnionType(['1']), A], false],
-  // `1 | :nothing.type` is not assignable to `?a: :atom.type`
+  // `1 | :Nothing` is not assignable to `?a: :Atom`
   [[makeUnionType(['1']), extendsAnyAtom], false],
-  // `a | :nothing.type` is not assignable to `?a: a`
+  // `a | :Nothing` is not assignable to `?a: a`
   [[makeUnionType(['a']), extendsSpecificAtom], false],
-  // `:atom.type | :nothing.type` is not assignable to `?a`
+  // `:Atom | :Nothing` is not assignable to `?a`
   [[makeUnionType([atom]), A], false],
-  // `:object.type | :nothing.type` is not assignable to `?a`
+  // `:Object | :Nothing` is not assignable to `?a`
   [[makeUnionType([object]), A], false],
-  // `?b | :nothing.type` is not assignable to `?a`
+  // `?b | :Nothing` is not assignable to `?a`
   [[makeUnionType([B]), A], false],
   // `?a | hello` is not assignable to `?a`
   [[makeUnionType([A, 'hello']), A], false],

--- a/src/language/semantics/type-system/type-formats/intrinsic-application-type.ts
+++ b/src/language/semantics/type-system/type-formats/intrinsic-application-type.ts
@@ -5,10 +5,10 @@ import type { Type } from './type.js'
 
 /**
  * A stuck application of a host-implemented standard library function. Standard
- * library functions whose return type is concrete (e.g. `:atom.type ~>
- * :atom.type ~> :atom.type` for `atom.append`) are lifted so their return
- * becomes one of these, letting the type system compute the result type from
- * argument types even when argument values are unelaborated.
+ * library functions whose return type is concrete (e.g. `:Atom ~> :Atom ~>
+ * :Atom` for `atom.append`) are lifted so their return becomes one of these,
+ * letting the type system compute the result type from argument types even when
+ * argument values are unelaborated.
  *
  * It reduces once every argument type's inhabitants can be exhaustively
  * enumerated (the type is finitely-sized). Until then it stays stuck, behaving

--- a/src/language/semantics/type-system/type-substitution.test.ts
+++ b/src/language/semantics/type-system/type-substitution.test.ts
@@ -588,9 +588,9 @@ const genericizeParameterAnnotationSuite = testCases(
 )
 
 genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
-  [['a', atom], '(?a: :atom.type)'],
+  [['a', atom], '(?a: :Atom)'],
 
-  [['a', integer], '(?a: :integer.type)'],
+  [['a', integer], '(?a: :Integer)'],
 
   [['a', makeUnionType(['foo', 'bar'])], '(?a: foo | bar)'],
 
@@ -604,7 +604,7 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
         b: atom,
       }),
     ],
-    '{ a: (?"x.a": :integer.type), b: (?"x.b": :atom.type) }',
+    '{ a: (?"x.a": :Integer), b: (?"x.b": :Atom) }',
   ],
 
   [
@@ -614,7 +614,7 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
         a: makeObjectType({ b: atom }),
       }),
     ],
-    '{ a: { b: (?"x.a.b": :atom.type) } }',
+    '{ a: { b: (?"x.a.b": :Atom) } }',
   ],
 
   [
@@ -624,7 +624,7 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
         callback: makeFunctionType({ parameter: atom, return: integer }),
       }),
     ],
-    '{ callback: (?"x.callback.#parameter": :atom.type) ~> (?"x.callback.#return": :integer.type) }',
+    '{ callback: (?"x.callback.#parameter": :Atom) ~> (?"x.callback.#return": :Integer) }',
   ],
 
   [['empty', makeObjectType({})], '(?empty: {})'],

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -51,7 +51,7 @@ import {
  * Drill into `type` using the given `keyPath`, returning `none` whenever no
  * match is found. A union can be drilled into only when every member contains
  * the key path; otherwise `none` is returned. A resolved type may legitimately
- * be the bottom type (e.g. `:nothing.type`), which is distinct from `none`.
+ * be the bottom type (e.g. `:Nothing`), which is distinct from `none`.
  */
 export const applyKeyPathToType = (
   type: Type,

--- a/src/language/unparsing/plz-utilities.ts
+++ b/src/language/unparsing/plz-utilities.ts
@@ -13,9 +13,7 @@ import {
   ignoredKey,
   isExpression,
   isSemanticGraph,
-  makeIndexExpression,
   makeLookupExpression,
-  objectNodeFromOrderedEntries,
   readApplyExpression,
   readFunctionExpression,
   readHoleExpression,
@@ -587,8 +585,12 @@ const unparseSugaredLookup =
       ),
     )
 
+// Serialization spells the top type as the prelude alias `:Something`, but the
+// `:something.type` property that alias points at is equally valid to write by
+// hand, so both spellings have to be recognized here.
 const isTopType = (value: SemanticGraph): boolean =>
   value === types.somethingTypeSymbol ||
+  isTopTypeAliasLookup(value) ||
   either.match(
     either.flatMap(readIndexExpression(value), ({ 1: { object, query } }) =>
       query[0] === 'type' && Object.keys(query).length === 1 ?
@@ -600,6 +602,12 @@ const isTopType = (value: SemanticGraph): boolean =>
       left: _ => false,
     },
   )
+
+const isTopTypeAliasLookup = (value: SemanticGraph): boolean =>
+  either.match(readLookupExpression(value), {
+    right: lookupExpression => lookupExpression[1].key === 'Something',
+    left: _ => false,
+  })
 
 const unparseSugaredHole =
   ({ unparseAtomOrMolecule }: Context) =>
@@ -771,7 +779,7 @@ const unparseSugaredUnion =
     const members = Object.values(expression[1])
 
     if (members.length === 0) {
-      return unparseSugaredIndex(context)(getBottomTypeAsSemanticGraph())
+      return unparseSugaredLookup(context)(getBottomTypeAsSemanticGraph())
     } else {
       // Unparse each member, adding parentheses when needed.
       return members.reduce(
@@ -892,7 +900,7 @@ const isTightlyBoundNonCompactExpression = (
 const isNonCompactExpression = (expression: SemanticGraph | Molecule) =>
   isTightlyBoundNonCompactExpression(expression) ||
   either.match(readUnionExpression(asSemanticGraph(expression)), {
-    // Empty unions render as `:nothing.type`.
+    // Empty unions render as `:Nothing`.
     right: unionExpression => Object.values(unionExpression[1]).length !== 0,
     left: _ => false,
   }) ||
@@ -903,8 +911,4 @@ const isNonCompactExpression = (expression: SemanticGraph | Molecule) =>
     ),
   )
 
-const getBottomTypeAsSemanticGraph = () =>
-  makeIndexExpression({
-    object: makeLookupExpression('nothing'),
-    query: objectNodeFromOrderedEntries([['0', 'type']]),
-  })
+const getBottomTypeAsSemanticGraph = () => makeLookupExpression('Nothing')


### PR DESCRIPTION
`:option.type(:natural_number.type)` is now `:Option(:NaturalNumber)`.