### PR TITLE
Type system enhancements

### DIFF
--- a/src/language/compiling/error-messages.test.ts
+++ b/src/language/compiling/error-messages.test.ts
@@ -59,8 +59,17 @@ suite('stuck applications are resolved in error messages', () => {
 suite('the top type is reported as itself', () => {
   test('a union which contains it collapses to it', () => {
     assertMessageContains(
-      '{ recurse: (k: :Atom) => (:object.lookup(:k)({ a: :recurse, b: true }) ~ :Nothing) }',
+      '(k: :Atom) => (:object.lookup(:k)({ a: :Something, b: true }) ~ :Nothing)',
       'value: :Something',
+    )
+  })
+})
+
+suite('a not-yet-known type is distinguished from the top type', () => {
+  test('a recursive definition reports the type it does not know', () => {
+    assertMessageContains(
+      '{ recurse: (k: :Atom) => (:object.lookup(:k)({ a: :recurse, b: true }) ~ :Nothing) }',
+      'value: :Unresolved | true',
     )
   })
 })

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -47,6 +47,7 @@ import {
   atomTypeSymbol,
   integerTypeSymbol,
   naturalNumberTypeSymbol,
+  pendingTypeSymbol,
   somethingTypeSymbol,
 } from './type-system/prelude-types.js'
 
@@ -54,6 +55,7 @@ export type TypeSymbol =
   | typeof atomTypeSymbol
   | typeof integerTypeSymbol
   | typeof naturalNumberTypeSymbol
+  | typeof pendingTypeSymbol
   | typeof somethingTypeSymbol
 
 export type SemanticGraph = Atom | TypeSymbol | FunctionNode | ObjectNode
@@ -442,6 +444,12 @@ export const typeSymbolToSemanticGraph = (typeSymbol: TypeSymbol): ObjectNode =>
           return 'Integer'
         case naturalNumberTypeSymbol:
           return 'NaturalNumber'
+        case pendingTypeSymbol:
+          // There isn't actually a user-facing thing named `:Unresolved`.
+          // TODO: Maybe there should be? Or alternatively this could return a
+          // special internal value that serialization knows to emit as a
+          // non-utterable expression (e.g. `#Unresolved` without quotes).
+          return 'Unresolved'
         case somethingTypeSymbol:
           return 'Something'
       }

--- a/src/language/semantics/type-system/prelude-types.ts
+++ b/src/language/semantics/type-system/prelude-types.ts
@@ -1,9 +1,15 @@
-import { atom, integer, naturalNumber } from './prelude-types/opaque-types.js'
+import {
+  atom,
+  integer,
+  naturalNumber,
+  pending,
+} from './prelude-types/opaque-types.js'
 import { something } from './prelude-types/transparent-types.js'
 import {
   atomTypeSymbol,
   integerTypeSymbol,
   naturalNumberTypeSymbol,
+  pendingTypeSymbol,
   somethingTypeSymbol,
 } from './prelude-types/type-symbols.js'
 
@@ -15,5 +21,6 @@ export const typesBySymbol = {
   [atomTypeSymbol]: atom,
   [integerTypeSymbol]: integer,
   [naturalNumberTypeSymbol]: naturalNumber,
+  [pendingTypeSymbol]: pending,
   [somethingTypeSymbol]: something,
 }

--- a/src/language/semantics/type-system/prelude-types/opaque-types.ts
+++ b/src/language/semantics/type-system/prelude-types/opaque-types.ts
@@ -1,11 +1,23 @@
 import optionAdt from '@matt.kantor/option'
-import { makeOpaqueType } from '../type-formats/opaque-type.js'
+import { makeOpaqueType, type OpaqueType } from '../type-formats/opaque-type.js'
 import { upperBoundOfStuckType } from '../type-substitution.js'
 import {
   atomTypeSymbol,
   integerTypeSymbol,
   naturalNumberTypeSymbol,
+  pendingTypeSymbol,
 } from './type-symbols.js'
+
+/**
+ * The type of an expression whose real type isn't known yet, which can happen
+ * during analysis of recursive definitions.
+ */
+export const pending: OpaqueType = {
+  symbol: pendingTypeSymbol,
+  kind: 'opaque',
+  isAssignableFrom: _source => true,
+  isAssignableTo: _target => true,
+}
 
 // The current type hierarchy for opaque types is:
 //  - atom

--- a/src/language/semantics/type-system/prelude-types/type-symbols.ts
+++ b/src/language/semantics/type-system/prelude-types/type-symbols.ts
@@ -2,6 +2,9 @@ export const atomTypeSymbol = Symbol('atom')
 export const integerTypeSymbol = Symbol('integer')
 export const naturalNumberTypeSymbol = Symbol('natural_number')
 
+// Users can't write this type, but it needs a symbol anyway.
+export const pendingTypeSymbol = Symbol('pending')
+
 // Despite not being opaque, `something` gets a type symbol to avoid
 // complications stemming from its circular definition.
 export const somethingTypeSymbol = Symbol('something')

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -1757,3 +1757,38 @@ typeAssignabilitySuite('union to type parameter (not assignable)', [
   // `?a | ?b` is not assignable to `?a`
   [[makeUnionType([A, B]), A], false],
 ])
+
+typeAssignabilitySuite('object source split over a union-valued property', [
+  // `{ tag: a | b, value: :Atom }` is assignable to `{ tag: a, value: :Atom } | { tag: b, value: :Atom }`
+  [
+    [
+      makeObjectType({ tag: makeUnionType(['a', 'b']), value: atom }),
+      makeUnionType([
+        makeObjectType({ tag: makeUnionType(['a']), value: atom }),
+        makeObjectType({ tag: makeUnionType(['b']), value: atom }),
+      ]),
+    ],
+    true,
+  ],
+
+  // `{ tag: a | b, value: :Atom }` is not assignable to `{ tag: a, value: :Atom } | { tag: b, value: :Integer }`
+  [
+    [
+      makeObjectType({ tag: makeUnionType(['a', 'b']), value: atom }),
+      makeUnionType([
+        makeObjectType({ tag: makeUnionType(['a']), value: atom }),
+        makeObjectType({ tag: makeUnionType(['b']), value: integer }),
+      ]),
+    ],
+    false,
+  ],
+
+  // `{ tag: a | b, value: :Atom }` is not assignable to `{ value: :Atom }`
+  [
+    [
+      makeObjectType({ tag: makeUnionType(['a', 'b']) }),
+      makeUnionType([makeObjectType({ value: atom })]),
+    ],
+    false,
+  ],
+])

--- a/src/language/semantics/type-system/subtyping.ts
+++ b/src/language/semantics/type-system/subtyping.ts
@@ -403,9 +403,83 @@ const isNonUnionAssignableToUnion = ({
         return true
       }
     }
-    return false
+    return decomposedObjectIsAssignableToUnion({ source, target })
   }
 }
+
+/**
+ * The dual of `simplifyUnionType`'s merging.
+ *
+ * `{ a | b, :A }` is be checked against `{ a, :A } | { b, :B }` by first
+ * decomposing the source to `{ a, :A } | { b, :A }`.
+ *
+ * Only one property is decomposed at a time. The recursive `isAssignable` call
+ * will make sure multiple get handled as needed.
+ */
+const decomposedObjectIsAssignableToUnion = ({
+  source,
+  target,
+}: {
+  readonly source: Exclude<Type, UnionType>
+  readonly target: UnionType
+}): boolean => {
+  if (source.kind !== 'object') {
+    return false
+  } else {
+    const [discriminant] = relevantDiscriminantsOfObjectType(source, target)
+    return discriminant === undefined ? false : (
+        discriminant.possibleValues.every(possibleValue =>
+          isAssignable({
+            source: makeObjectType(
+              {
+                ...source.children,
+                [discriminant.key]: makeUnionType([possibleValue]),
+              },
+              source.excess,
+            ),
+            target,
+          }),
+        )
+      )
+  }
+}
+
+type ObjectTypeDiscriminant = {
+  readonly key: Atom
+  readonly possibleValues: readonly Atom[]
+}
+
+/**
+ * Properties of `source` potentially worth splitting on for assignability
+ * checks: unions of literal atoms which some member of `target` also requires.
+ * Splitting on anything else would be wasted work.
+ */
+const relevantDiscriminantsOfObjectType = (
+  source: ObjectType,
+  target: UnionType,
+): readonly ObjectTypeDiscriminant[] =>
+  Object.entries(source.children).flatMap(
+    ([key, child]): readonly ObjectTypeDiscriminant[] =>
+      child.kind !== 'union' || !someMemberOfUnionRequiresKey(key, target) ?
+        []
+      : option.match(asUnionWithLiteralAtomMembers(child), {
+          none: _ => [],
+          some: atoms =>
+            atoms.members.size > 1 ?
+              [{ key, possibleValues: [...atoms.members] }]
+            : [],
+        }),
+  )
+
+const someMemberOfUnionRequiresKey = (key: Atom, union: UnionType): boolean =>
+  union.members
+    .values()
+    .some(
+      member =>
+        typeof member !== 'string' &&
+        member.kind === 'object' &&
+        member.children[key] !== undefined,
+    )
 
 const isUnionAssignableToNonUnion = ({
   source,

--- a/src/language/semantics/type-system/type-formats/type-parameter-type.ts
+++ b/src/language/semantics/type-system/type-formats/type-parameter-type.ts
@@ -20,6 +20,22 @@ export const makeTypeParameter = (
   constraint,
 })
 
+/**
+ * A copy of `typeParameter` with its constraint replaced, preserving the
+ * `TypeParameter`'s `identity`.
+ */
+export const typeParameterWithConstraint = (
+  typeParameter: TypeParameter,
+  assignableTo: Type,
+): TypeParameter =>
+  assignableTo === typeParameter.constraint.assignableTo ?
+    // Avoid an unnecessary allocation.
+    typeParameter
+  : {
+      ...typeParameter,
+      constraint: { ...typeParameter.constraint, assignableTo },
+    }
+
 export const isTypeParameter = (value: unknown): value is TypeParameter => {
   // This doesn't exhaustively validate (it doesn't look inside `constraint`),
   // but something very weird would have to be going on for this to have a false

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -284,8 +284,9 @@ const inferTypeImplementation = (
         return either.makeRight(types.something)
       }
     } else {
-      // Fall back to the top type.
-      return either.makeRight(types.something)
+      // Inference has re-entered a key it is already resolving, so this is a
+      // recursive definition whose type isn't known yet.
+      return either.makeRight(types.pending)
     }
   }
 

--- a/src/language/semantics/type-system/type-substitution.test.ts
+++ b/src/language/semantics/type-system/type-substitution.test.ts
@@ -18,6 +18,7 @@ import {
   makeObjectType,
   makeTypeParameter,
   makeUnionType,
+  typeParameterWithConstraint,
   type Type,
   type TypeParameter,
 } from '../type-system.js'
@@ -761,6 +762,35 @@ supplyTypeArgumentSuite('supplying type arguments within excess bounds', [
 
   [[object, A, atom], object],
 ])
+
+const boundedByA = makeTypeParameter('m', {
+  assignableTo: makeObjectType({ tag: A }),
+})
+
+supplyTypeArgumentSuite(
+  'supplying type arguments within parameter constraints',
+  [
+    [
+      [boundedByA, A, atom],
+      typeParameterWithConstraint(boundedByA, makeObjectType({ tag: atom })),
+    ],
+
+    [
+      [makeFunctionType({ parameter: A, return: boundedByA }), A, atom],
+      makeFunctionType({
+        parameter: atom,
+        return: typeParameterWithConstraint(
+          boundedByA,
+          makeObjectType({ tag: atom }),
+        ),
+      }),
+    ],
+
+    [[boundedByA, B, atom], boundedByA],
+
+    [[boundedByA, boundedByA, atom], atom],
+  ],
+)
 
 const containedTypeParametersSuite = testCases(
   (type: Type) => [

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -26,6 +26,7 @@ import { matchTypeFormat } from './type-formats/match-type-format.js'
 import { makeObjectType, type ObjectType } from './type-formats/object-type.js'
 import {
   makeTypeParameter,
+  typeParameterWithConstraint,
   type TypeParameter,
 } from './type-formats/type-parameter-type.js'
 import {
@@ -295,6 +296,7 @@ const upperBoundOfResolvableStuckType = (
  * assignability to `argument`. Callers should use `supplyTypeArguments` to
  * create a concrete type and then perform any needed checks.
  */
+// TODO: Key the return with identity symbols instead of full `TypeParameter`s.
 export const getTypesForTypeParameters = ({
   parameterType,
   argumentType,
@@ -829,7 +831,18 @@ export const supplyTypeArgument = (
       },
       opaque: type => type,
       parameter: type =>
-        type.identity === typeParameter.identity ? typeArgument : type,
+        type.identity === typeParameter.identity ?
+          typeArgument
+        : typeParameterWithConstraint(
+            type,
+            // A parameter which isn't the one being supplied may still mention
+            // it in the constraint.
+            supplyTypeArgument(
+              type.constraint.assignableTo,
+              typeParameter,
+              typeArgument,
+            ),
+          ),
       union: type =>
         makeUnionType(
           [...type.members].flatMap(member => {


### PR DESCRIPTION
Each commit stands on its own, but together they're helping to pave the way towards more legit typing of the `match` builtin.