### PR TITLE
Make `match`'s type righteous

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -371,22 +371,15 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     success({ true: 'true', false: 'false' }),
   ],
   [
-    `@runtime {
-      :flow(
-        :match({
-          none: _ => "environment does not exist"
-          some: :flow(
-            :match({
-              none: _ => "environment.lookup does not exist"
-              some: :apply(PATH)
-            })
-          )(
-            :object.lookup(lookup)
-          )
-        })
-      )(
-        :object.lookup(environment)
-      )
+    `@runtime { context =>
+      :context |> :object.lookup(environment) |> :match({
+        none: _ => "environment does not exist"
+        some: (environment: { lookup: :Atom ~> :Option(:Atom) }) =>
+          (:environment |> :object.lookup(lookup) |> :match({
+            none: _ => "environment.lookup does not exist"
+            some: (lookup: :Atom ~> :Option(:Atom)) => :lookup(PATH)
+          }))
+      })
     }`,
     output => {
       if (either.isLeft(output)) {
@@ -645,6 +638,13 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       some: :identity
     }`,
     success('_'),
+  ],
+  [
+    `:option.none match {
+      none: (n: :Integer) => :n
+      some: :identity
+    }`,
+    typeMismatch,
   ],
   [':option.is_some(:option.make_some(7))', success('true')],
   [':option.is_some(:option.none)', success('false')],
@@ -1204,6 +1204,20 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       output: :numbers sum :start
     }.output`,
     success({ tag: 'some', value: '60' }),
+  ],
+  [
+    `{
+      needs_integer: (n: :Integer) => _
+      input: @runtime { context =>
+        :context.arguments.lookup(input)
+      }
+      output: :input
+        option.flat_map :boolean.from match {
+          none: _ => nothing_to_do
+          some: :needs_integer
+        }
+    }.output`,
+    typeMismatch,
   ],
   [
     `{

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -2138,22 +2138,21 @@ testCases(
   ],
 
   [
-    // TODO: This should be rejected by static analysis (the `match` object is
-    // not exhaustive).
     `{
       test: a =>
         :integer.from(:a) match {
+          // missing the none case
           some: _ => 1
         }
     }`,
     result => {
-      assert(either.isRight(result))
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
     },
   ],
 
   [
-    // TODO: This should be rejected by static analysis (a case has an incorrect
-    // parameter type).
     `{
       test: a =>
         :integer.from(:a) match {
@@ -2162,13 +2161,13 @@ testCases(
         }
     }`,
     result => {
-      assert(either.isRight(result))
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
     },
   ],
 
   [
-    // TODO: This should be rejected by static analysis (`:a` may have arbitrary
-    // tags).
     `{
       test: (a: { tag: :Atom, value: :Something }) =>
         :a match {
@@ -2177,7 +2176,58 @@ testCases(
         }
     }`,
     result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{
+      test: (a: { tag: some | none }) =>
+        :a match {
+          some: _ => 1
+          none: _ => 2
+        }
+    }`,
+    result => {
       assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      test: (a: { tag: some, value: :Integer }) =>
+        (:a match { some: (b: :Integer) => :b }) ~ :Integer
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      test: (a: :Atom) => :apply(:integer.from(:a))(:match({ some: _ => 1 }))
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{
+      test: (a: :Atom) =>
+        :option.make_some(:integer.from(:a)) option.map :match({
+          some: (b: :Boolean) => 1
+          none: _ => 2
+        })
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
     },
   ],
 

--- a/src/language/semantics/stdlib/global-functions.ts
+++ b/src/language/semantics/stdlib/global-functions.ts
@@ -9,7 +9,10 @@ import {
 import {
   isAssignable,
   makeFunctionType,
+  makeIntrinsicApplicationType,
+  makeObjectType,
   makeTypeParameter,
+  makeUnionType,
   matchTypeFormat,
   types,
   unionOfTypes,
@@ -21,14 +24,20 @@ import {
   excessBoundForKey,
 } from '../type-system/subtyping.js'
 import {
+  applicableFunctionSignatures,
   applyKeyPathToType,
   applyTypeToArgumentType,
+  concreteUpperBound,
+  replaceAllTypeParametersWithTheirConstraints,
 } from '../type-system/type-substitution.js'
 import {
   anyValue,
   functionParameter,
   objectOfFunctionsParameter,
   taggedParameter,
+  typeOfParameter,
+  type Parameter,
+  type TaggedNode,
 } from './parameters.js'
 import {
   applyValidatingParameterType,
@@ -54,14 +63,16 @@ const computeMatchReturnType = (parameterTypes: readonly Type[]): Type => {
     // For every statically-known tag of the matchee, look up the case for that
     // tag and apply its type to the matchee's `value` type.
     return option.match(
-      option.flatMap(enumerateTaggedVariants(matcheeType), variants =>
-        option.sequence(
-          variants.map(({ tag, value }) =>
-            option.flatMap(applyKeyPathToType(casesType, [tag]), caseType =>
-              applyTypeToArgumentType(caseType, value),
+      option.flatMap(
+        enumerateTaggedVariants(matcheeUpperBound(matcheeType)),
+        variants =>
+          option.sequence(
+            variants.map(({ tag, value }) =>
+              option.flatMap(applyKeyPathToType(casesType, [tag]), caseType =>
+                applyTypeToArgumentType(caseType, value),
+              ),
             ),
           ),
-        ),
       ),
       {
         none: _ =>
@@ -72,6 +83,35 @@ const computeMatchReturnType = (parameterTypes: readonly Type[]): Type => {
       },
     )
   }
+}
+
+const anyTaggedValue = typeOfParameter(taggedParameter, [])
+
+const matcheeParameter: Parameter<TaggedNode> = {
+  ...taggedParameter,
+  // The `matchee`'s type is constrained by the cases object supplied to `match`
+  // parameter.
+  type: ([casesType]) =>
+    casesType === undefined ? anyTaggedValue : (
+      makeIntrinsicApplicationType(
+        [casesType],
+        ([cases]) =>
+          cases === undefined ?
+            either.makeLeft({
+              kind: 'bug',
+              message:
+                "`match`'s matchee type was computed without cases being known",
+            })
+          : either.map(
+              typeFromSemanticGraph(cases, { objectsAreExact: true }),
+              matcheeTypeForCases,
+            ),
+        ([casesType]) =>
+          casesType === undefined ? anyTaggedValue : (
+            matcheeTypeForCases(casesType)
+          ),
+      )
+    ),
 }
 
 export const globalFunctions = {
@@ -157,12 +197,9 @@ export const globalFunctions = {
       ),
   ),
 
-  // TODO: Tighten this up, rejecting:
-  //  - Non-exhaustive cases.
-  //  - Case functions with incorrect parameter types.
   match: preludeFunction(
     ['match'],
-    [objectOfFunctionsParameter, taggedParameter],
+    [objectOfFunctionsParameter, matcheeParameter],
     types.something,
     cases =>
       either.makeRight((argument, contextOfApplication) => {
@@ -188,14 +225,61 @@ export const globalFunctions = {
  */
 const unitValue: Atom = '_'
 
+/**
+ * The widest matchee type the given cases can handle.
+ */
+const matcheeTypeForCases = (casesType: Type): Type =>
+  casesType.kind !== 'object' ?
+    anyTaggedValue
+  : unionOfTypes(
+      Object.entries(casesType.children).map(([tag, caseType]) => {
+        const acceptedPayloadType = option.match(
+          payloadTypeAcceptedByCase(caseType),
+          {
+            // A case whose type isn't a single function type (see
+            // `payloadTypeAcceptedByCase`) doesn't constrain its payload.
+            // `match` validates payloads against the applied case, so a bad
+            // payload type is still rejected, just later.
+            none: _ => types.something,
+            some: payloadType => payloadType,
+          },
+        )
+        // A variant with no `value` passes the unit value, so `value` is only
+        // required when unit wouldn't satisfy the case.
+        return isAssignable({ source: types._, target: acceptedPayloadType }) ?
+            makeObjectType({ tag: makeUnionType([tag]) }, [
+              { keys: makeUnionType(['value']), values: acceptedPayloadType },
+            ])
+          : makeObjectType({
+              tag: makeUnionType([tag]),
+              value: acceptedPayloadType,
+            })
+      }),
+    )
+
+const payloadTypeAcceptedByCase = (caseType: Type): Option<Type> =>
+  option.flatMap(
+    applicableFunctionSignatures(caseType),
+    // TODO: Satisfying multiple signatures would require intersection types.
+    ([signature, ...additionalSignatures]) =>
+      signature === undefined || additionalSignatures.length > 0 ?
+        option.none
+      : option.makeSome(
+          replaceAllTypeParametersWithTheirConstraints(signature.parameter),
+        ),
+  )
+
+type TaggedVariant = {
+  readonly tag: Atom
+  readonly value: Type
+}
+
+const matcheeUpperBound = (matcheeType: Type): Type =>
+  concreteUpperBound(replaceAllTypeParametersWithTheirConstraints(matcheeType))
+
 const enumerateTaggedVariants = (
   type: Type,
-): Option<
-  readonly {
-    readonly tag: Atom
-    readonly value: Type
-  }[]
-> =>
+): Option<readonly TaggedVariant[]> =>
   matchTypeFormat(type, {
     union: type =>
       option.map(

--- a/src/language/semantics/stdlib/parameters.ts
+++ b/src/language/semantics/stdlib/parameters.ts
@@ -12,6 +12,7 @@ import {
   makeUnionType,
   types,
   type Type,
+  type TypeParameter,
 } from '../type-system.js'
 
 /**
@@ -20,12 +21,28 @@ import {
  * `Parameter<Atom>`s).
  */
 export type Parameter<Value extends SemanticGraph> = {
-  readonly type: Type
+  readonly type: Type | ParameterTypeFromPrecedingParameters
   readonly asExpected: (value: SemanticGraph) => Option<Value>
   readonly expected: string
 }
 
+export type ParameterTypeFromPrecedingParameters = (
+  precedingTypeParameters: readonly TypeParameter[],
+) => Type
+
 export type AnyParameter = Parameter<SemanticGraph>
+
+export const typeOfParameter = (
+  parameter: AnyParameter,
+  precedingTypeParameters: readonly TypeParameter[],
+): Type =>
+  typeof parameter.type === 'function' ?
+    parameter.type(precedingTypeParameters)
+  : parameter.type
+
+export const parameterTypeDependsOnPrecedingParameters = (
+  parameter: AnyParameter,
+): boolean => typeof parameter.type === 'function'
 
 export type NonEmptyParameters = readonly [
   AnyParameter,

--- a/src/language/semantics/stdlib/stdlib-utilities.test.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.test.ts
@@ -18,9 +18,14 @@ import {
   type FunctionNode,
   type SemanticGraph,
 } from '../../semantics.js'
+import { makeTypeParameter } from '../type-system.js'
 import { globalFunctions } from './global-functions.js'
 import { option as optionModule } from './option.js'
-import { emptyContextForStdlibApplications } from './stdlib-utilities.js'
+import { anyValue } from './parameters.js'
+import {
+  emptyContextForStdlibApplications,
+  preludeFunction,
+} from './stdlib-utilities.js'
 
 const applicationChain: readonly ApplicationChainEntry[] = [
   {
@@ -103,6 +108,30 @@ suite('evaluation state across host-driven applications', _ => {
     assert.deepEqual(contextSeenByCase?.applicationChain, applicationChain)
     assert.deepEqual(contextSeenByCase?.applicationsAreSpeculative, true)
   })
+})
+
+test('a computed parameter bound forces lifting', _ => {
+  const first = makeTypeParameter('a', { assignableTo: types.something })
+  const { signature } = preludeFunction(
+    ['test_function'],
+    [
+      anyValue(first),
+      {
+        ...anyValue(types.something),
+        type: ([preceding]) => preceding ?? types.something,
+      },
+    ],
+    first,
+    _firstArgument =>
+      either.makeRight(secondArgument => either.makeRight(secondArgument)),
+  )
+  assert(signature.return.kind === 'function')
+  const secondMintedParameter = signature.return.signature.parameter
+  assert(secondMintedParameter.kind === 'parameter')
+  assert.equal(
+    secondMintedParameter.constraint.assignableTo,
+    signature.parameter,
+  )
 })
 
 const compileAndRun = testCases(

--- a/src/language/semantics/stdlib/stdlib-utilities.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.ts
@@ -31,6 +31,7 @@ import {
   makeTypeParameter,
   type FunctionType,
   type Type,
+  type TypeParameter,
 } from '../type-system.js'
 import { typeFromSemanticGraph } from '../type-system/literal-type.js'
 import { isAssignable } from '../type-system/subtyping.js'
@@ -40,10 +41,12 @@ import {
   replaceAllTypeParametersWithTheirConstraints,
   supplyTypeArguments,
 } from '../type-system/type-substitution.js'
-import type {
-  AnyParameter,
-  NonEmptyParameters,
-  Parameter,
+import {
+  parameterTypeDependsOnPrecedingParameters,
+  typeOfParameter,
+  type AnyParameter,
+  type NonEmptyParameters,
+  type Parameter,
 } from './parameters.js'
 
 const handleUnavailableDependencies =
@@ -162,8 +165,9 @@ export const preludeFunction = <const Parameters extends NonEmptyParameters>(
     parameters,
     body,
   }
-  const liftedSignature = liftIntrinsicSignature(
-    signatureFromParameters(parameters, returnType),
+  const liftedSignature = genericizeIntrinsicSignature(
+    parameters,
+    returnType,
     argumentValues =>
       either.flatMap(applyBody(definition)(argumentValues), resultValue =>
         typeFromSemanticGraph(resultValue, { objectsAreExact: true }),
@@ -203,10 +207,13 @@ const signatureFromParameters = (
 ): FunctionType['signature'] => {
   const [firstParameter, ...restParameters] = parameters
   return {
-    parameter: firstParameter.type,
+    parameter: typeOfParameter(firstParameter, []),
     return: restParameters.reduceRight(
       (returnSoFar, parameter) =>
-        makeFunctionType({ parameter: parameter.type, return: returnSoFar }),
+        makeFunctionType({
+          parameter: typeOfParameter(parameter, []),
+          return: returnSoFar,
+        }),
       returnType,
     ),
   }
@@ -378,33 +385,22 @@ const synthesizeTypeParameterName = (index: number) => {
   }
 }
 
-type SignatureParts = {
-  // The constraint at each curried parameter position, in application order.
-  readonly parameterConstraints: readonly Type[]
-  // The innermost (non-function) return type.
-  readonly finalReturn: Type
-}
-
-const signatureParts = (
-  signature: FunctionType['signature'],
-): SignatureParts => {
-  const prependParameter = (
-    parameter: Type,
-    { parameterConstraints, finalReturn }: SignatureParts,
-  ): SignatureParts => ({
-    parameterConstraints: [parameter, ...parameterConstraints],
-    finalReturn,
-  })
-  const partsFromReturn = (returnType: Type): SignatureParts =>
-    returnType.kind === 'function' ?
-      prependParameter(
-        returnType.signature.parameter,
-        partsFromReturn(returnType.signature.return),
-      )
-    : { parameterConstraints: [], finalReturn: returnType }
-  return prependParameter(
-    signature.parameter,
-    partsFromReturn(signature.return),
+const synthesizedTypeParameters = (
+  parameters: NonEmptyParameters,
+): readonly [TypeParameter, ...TypeParameter[]] => {
+  const [firstParameter, ...restParameters] = parameters
+  return restParameters.reduce<readonly [TypeParameter, ...TypeParameter[]]>(
+    (mintedSoFar, parameter, index) => [
+      ...mintedSoFar,
+      makeTypeParameter(synthesizeTypeParameterName(index + 1), {
+        assignableTo: typeOfParameter(parameter, mintedSoFar),
+      }),
+    ],
+    [
+      makeTypeParameter(synthesizeTypeParameterName(0), {
+        assignableTo: typeOfParameter(firstParameter, []),
+      }),
+    ],
   )
 }
 
@@ -413,12 +409,10 @@ const signatureParts = (
  * parameters and return an `IntrinsicApplicationType`. This lets the type
  * system compute precise return types from singleton argument types via
  * `reduce` (which should apply the function itself).
- *
- * Functions whose return already contains a type parameter (e.g. `identity`)
- * don't need extra precision, so their signature is left unchanged.
  */
-const liftIntrinsicSignature = (
-  signature: FunctionType['signature'],
+const genericizeIntrinsicSignature = (
+  parameters: NonEmptyParameters,
+  returnType: Type,
   reduce: (
     argumentValues: readonly SemanticGraph[],
   ) => Either<FunctionNodeCallError, Type>,
@@ -426,28 +420,30 @@ const liftIntrinsicSignature = (
   // Defaults to the function's (concrete) declared return type.
   computeRefinedReturnType?: (argumentTypes: readonly Type[]) => Type,
 ): FunctionType['signature'] => {
-  if (containedTypeParameters(makeFunctionType(signature)).size > 0) {
-    return signature
+  const declaredSignature = signatureFromParameters(parameters, returnType)
+  // The signature doesn't need adjustment if it's already generic, unless its
+  // type parameters depend on one another.
+  if (
+    !parameters.some(parameterTypeDependsOnPrecedingParameters) &&
+    containedTypeParameters(makeFunctionType(declaredSignature)).size > 0
+  ) {
+    return declaredSignature
   } else {
-    const { parameterConstraints, finalReturn } = signatureParts(signature)
     // Make signatures implicitly generic, just like userland functions.
-    const parameterTypes = parameterConstraints.map((constraint, index) =>
-      makeTypeParameter(synthesizeTypeParameterName(index), {
-        assignableTo: constraint,
-      }),
-    )
-    const liftedFunctionType = parameterTypes.reduceRight<Type>(
-      (returnSoFar, parameter) =>
-        makeFunctionType({ parameter, return: returnSoFar }),
-      makeIntrinsicApplicationType(
-        parameterTypes,
-        reduce,
-        computeRefinedReturnType ?? (() => finalReturn),
+    const [firstParameterType, ...restParameterTypes] =
+      synthesizedTypeParameters(parameters)
+    return {
+      parameter: firstParameterType,
+      return: restParameterTypes.reduceRight<Type>(
+        (returnSoFar, parameter) =>
+          makeFunctionType({ parameter, return: returnSoFar }),
+        makeIntrinsicApplicationType(
+          [firstParameterType, ...restParameterTypes],
+          reduce,
+          computeRefinedReturnType ?? (() => returnType),
+        ),
       ),
-    )
-    return liftedFunctionType.kind === 'function' ?
-        liftedFunctionType.signature
-      : signature
+    }
   }
 }
 

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -1198,6 +1198,27 @@ typeAssignabilitySuite('excess clauses', [
     ],
     false,
   ],
+  [
+    [
+      makeObjectType({ a: atom }),
+      makeObjectType({}, [{ keys: makeUnionType(['a']), values: atom }]),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType({ a: atom }),
+      makeObjectType({}, [{ keys: makeUnionType(['a', 'b']), values: atom }]),
+    ],
+    false,
+  ],
+  [
+    [
+      makeObjectType({ a: something }),
+      makeObjectType({}, [{ keys: makeUnionType(['a']), values: atom }]),
+    ],
+    false,
+  ],
 ])
 
 typeAssignabilitySuite('generic function types (assignable)', [

--- a/src/language/semantics/type-system/subtyping.ts
+++ b/src/language/semantics/type-system/subtyping.ts
@@ -267,6 +267,9 @@ export const isAssignable = ({
               // irrelevant to subtyping.
               const sourceExcess = effectiveExcessClauses(source.excess)
               const targetExcess = effectiveExcessClauses(target.excess)
+              const keysListedBySource = makeUnionType(
+                Object.keys(source.children),
+              )
               const excessClausesAreSatisfied = sourceExcess.every(
                 (sourceClause, sourceIndex) =>
                   targetExcess.every((targetClause, targetIndex) => {
@@ -286,6 +289,10 @@ export const isAssignable = ({
                       isAssignable({
                         source: targetClause.keys,
                         target: laterDomains,
+                      }) ||
+                      isAssignable({
+                        source: targetClause.keys,
+                        target: keysListedBySource,
                       })
                     return (
                       pairIsUnreachable ||


### PR DESCRIPTION
- Exhaustiveness checking
- Forbid cases with mis-typed parameters