### PR TITLE
Let a stuck union member satisfy a union target as a whole

### DIFF
--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -1813,3 +1813,29 @@ typeAssignabilitySuite('object source split over a union-valued property', [
     false,
   ],
 ])
+
+// The upper bound is `atom | object`, which is assignable to `something` but
+// not to any of its individual members.
+const stuckIntrinsicApplicationSpanningTopTypeMembers =
+  makeIntrinsicApplicationType(
+    [object],
+    _argumentValues => either.makeRight(something),
+    _parameterTypes => makeUnionType(['an atom', makeObjectType({})]),
+  )
+
+typeAssignabilitySuite('union member standing for an unresolved type', [
+  [[stuckIntrinsicApplicationSpanningTopTypeMembers, something], true],
+
+  [
+    [
+      makeUnionType([stuckIntrinsicApplicationSpanningTopTypeMembers]),
+      something,
+    ],
+    true,
+  ],
+
+  [
+    [makeUnionType([stuckIntrinsicApplicationSpanningTopTypeMembers]), atom],
+    false,
+  ],
+])

--- a/src/language/semantics/type-system/subtyping.ts
+++ b/src/language/semantics/type-system/subtyping.ts
@@ -363,13 +363,13 @@ export const isAssignable = ({
                       }
                     }
                   }
-                  // A type parameter member can be assignable to the target
-                  // union while matching no single member, e.g. a parameter
-                  // constrained to `something` is assignable to `something`
-                  // even though `something` is itself a union.
+                  // A stuck member can be assignable to the target union even
+                  // if it's not assignable to any single member of it, e.g. the
+                  // stuck type's upper bound could itself be a union which
+                  // spans multiple members.
                   return (
                     typeof sourceMember !== 'string' &&
-                    sourceMember.kind === 'parameter' &&
+                    isStuck(sourceMember) &&
                     isAssignable({ source: sourceMember, target })
                   )
                 })()
@@ -384,6 +384,12 @@ export const isAssignable = ({
       }))
   )
 }
+
+const isStuck = (type: Exclude<Type, UnionType>): boolean =>
+  type.kind === 'parameter' ||
+  type.kind === 'application' ||
+  type.kind === 'indexedAccess' ||
+  type.kind === 'intrinsicApplication'
 
 const isNonUnionAssignableToUnion = ({
   source,


### PR DESCRIPTION
There was already a special case to allow type parameters to be assignable to unions when their upper bound spans multiple members. That case has now been generalized to apply to all stuck types, not just type parameters.